### PR TITLE
fix: more structured logs for tracking specific orders

### DIFF
--- a/src/executors/mod.rs
+++ b/src/executors/mod.rs
@@ -1,4 +1,3 @@
 pub mod protect_executor;
 pub mod public_1559_executor;
 pub mod reactor_error_code;
-

--- a/src/executors/public_1559_executor.rs
+++ b/src/executors/public_1559_executor.rs
@@ -48,7 +48,7 @@ where
             .acquire_key()
             .await
             .expect("Failed to acquire key");
-        info!("{} - Acquired key: {:?}", order_hash, public_address);
+        info!("{} - Acquired key: {}", order_hash, public_address);
 
         let chain_id = u64::from_str_radix(
             &action

--- a/src/executors/reactor_error_code.rs
+++ b/src/executors/reactor_error_code.rs
@@ -1,16 +1,16 @@
 pub enum ReactorErrorCode {
-  OrderNotFillable, 
-  Unknown,
+    OrderNotFillable,
+    Unknown,
 }
 
 // implements the From trait for the ReactorErrorCode enum to convert it to a string
 impl From<String> for ReactorErrorCode {
-  fn from(s: String) -> Self {
-    match s.as_str() {
-      "0xc6035520" => ReactorErrorCode::OrderNotFillable,
-      _ => ReactorErrorCode::Unknown,
+    fn from(s: String) -> Self {
+        match s.as_str() {
+            "0xc6035520" => ReactorErrorCode::OrderNotFillable,
+            _ => ReactorErrorCode::Unknown,
+        }
     }
-  }
 }
 
 impl std::fmt::Display for ReactorErrorCode {
@@ -20,5 +20,5 @@ impl std::fmt::Display for ReactorErrorCode {
             ReactorErrorCode::Unknown => "Unknown",
         };
         write!(f, "{}", s)
-    } 
+    }
 }

--- a/src/strategies/priority_strategy.rs
+++ b/src/strategies/priority_strategy.rs
@@ -297,7 +297,7 @@ impl<M: Middleware + 'static> UniswapXPriorityFill<M> {
         for log in logs {
             let order_hash = format!("0x{:x}", log.topics[1]);
             // remove from open
-            info!("Removing filled order {}", order_hash);
+            info!("{} - Removing filled order", order_hash);
             self.open_orders_mut().remove(&order_hash);
             // add to done
             self.done_orders.insert(
@@ -358,19 +358,19 @@ impl<M: Middleware + 'static> UniswapXPriorityFill<M> {
                 self.mark_as_done(&order_hash);
             }
             OrderStatus::NotFillableYet => {
-                info!("Order not fillable yet, skipping: {}", order_hash);
+                info!("{} - Order not fillable yet, skipping", order_hash);
             }
             OrderStatus::Open(resolved_order) => {
                 if self.done_orders.contains_key(order_hash) {
-                    info!("Order already done, skipping: {}", order_hash);
+                    info!("{} - Order already done, skipping", order_hash);
                     return;
                 }
                 if self.open_orders().contains_key(order_hash) {
                     let existing_order = self.open_orders_mut().get_mut(order_hash).unwrap();
-                    info!("Updating order {}", order_hash);
+                    info!("{} - Updating order", order_hash);
                     existing_order.resolved = resolved_order;
                 } else {
-                    info!("Adding new order {}", order_hash);
+                    info!("{} - Adding new order", order_hash);
                     self.open_orders_mut().insert(
                         order_hash.clone(),
                         OrderData {

--- a/src/strategies/uniswapx_strategy.rs
+++ b/src/strategies/uniswapx_strategy.rs
@@ -266,7 +266,7 @@ impl<M: Middleware + 'static> UniswapXUniswapFill<M> {
         for log in logs {
             let order_hash = format!("0x{:x}", log.topics[1]);
             // remove from open
-            info!("Removing filled order {}", order_hash);
+            info!("{} - Removing filled order", order_hash);
             self.open_orders.remove(&order_hash);
             // add to done
             self.done_orders.insert(
@@ -335,11 +335,11 @@ impl<M: Middleware + 'static> UniswapXUniswapFill<M> {
             }
             OrderStatus::Open(resolved_order) => {
                 if self.done_orders.contains_key(order_hash) {
-                    info!("Order already done, skipping: {}", order_hash);
+                    info!("{} - Order already done, skipping", order_hash);
                     return;
                 }
                 if !self.open_orders.contains_key(order_hash) {
-                    info!("Adding new order {}", order_hash);
+                    info!("{} - Adding new order", order_hash);
                 }
                 self.open_orders.insert(
                     order_hash.clone(),


### PR DESCRIPTION
example logs:
```
 cat logs | grep '0x1b25ce...'   

2024-09-09T21:11:07.043643Z  INFO 0x1b25ce..- Order not fillable yet, skipping
2024-09-09T21:11:08.065986Z  INFO 0x1b25ce.. - Order not fillable yet, skipping
2024-09-09T21:11:09.094955Z  INFO 0x1b25ce.. - Adding new order
2024-09-09T21:11:10.152835Z  INFO  0x1b25ce.. - Acquired key: 0xf…7
2024-09-09T21:11:10.154102Z  INFO 0x1b25ce.. -Updating order
2024-09-09T21:11:10.505155Z  INFO 0x1b25ce.. - Updating order
2024-09-09T21:11:10.521886Z  INFO 0x1b25ce.. - Executing tx from 0xe9..
2024-09-09T21:11:11.033433Z  INFO 0x1b25ce.. - Updating order
2024-09-09T21:11:12.057695Z  INFO 0x1b25ce.. -Updating order
2024-09-09T21:11:12.207284Z  INFO 0x1b25ce.. - Removing filled order
2024-09-09T21:11:13.029378Z  INFO 0x1b25ce.. -Order already done, skipping
2024-09-09T21:11:17.715017Z  INFO 0x1b25ce.. - receipt: tx_hash: 0xa..., status: 1
```