### PR TITLE
feat: use a reader-writer lock for open_orders

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1297,6 +1297,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.0",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5022,6 +5036,7 @@ dependencies = [
  "clap",
  "crossbeam",
  "crossbeam-channel",
+ "dashmap",
  "dotenv",
  "ethers",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,3 +34,4 @@ mockito = "1.1.0"
 aws-config = { version = "1.1.7", features = ["behavior-version-latest"] }
 aws-sdk-secretsmanager = "1.43.0"
 serde_json = "1.0.127"
+dashmap = "6.1.0"

--- a/src/strategies/priority_strategy.rs
+++ b/src/strategies/priority_strategy.rs
@@ -65,7 +65,6 @@ impl ExecutionMetadata {
         let mps_of_improvement = profit_quote
             .saturating_mul(U256::from(MPS))
             .checked_div(self.amount_out_required)?;
-        info!("mps_of_improvement: {}", mps_of_improvement);
         let priority_fee = mps_of_improvement
             .checked_mul(U256::from(bid_percentage))?
             .checked_div(U256::from(100))?;
@@ -358,7 +357,10 @@ impl<M: Middleware + 'static> UniswapXPriorityFill<M> {
                 self.mark_as_done(&order_hash);
             }
             OrderStatus::NotFillableYet => {
-                info!("Order not fillable yet, skipping: {}", order_hash);
+                info!(
+                    "{} - Order not fillable yet - last block: {}, target: {}",
+                    order_hash, self.last_block_number, order.cosignerData.auctionTargetBlock
+                );
             }
             OrderStatus::Open(resolved_order) => {
                 if self.done_orders.contains_key(order_hash) {

--- a/src/strategies/priority_strategy.rs
+++ b/src/strategies/priority_strategy.rs
@@ -357,7 +357,6 @@ impl<M: Middleware + 'static> UniswapXPriorityFill<M> {
 
         match order_status {
             OrderStatus::Done => {
-                self.remove_open_order(&order_hash);
                 self.mark_as_done(&order_hash);
             }
             OrderStatus::NotFillableYet => {

--- a/src/strategies/priority_strategy.rs
+++ b/src/strategies/priority_strategy.rs
@@ -247,7 +247,7 @@ impl<M: Middleware + 'static> UniswapXPriorityFill<M> {
         self.last_block_number = event.number.as_u64();
         self.last_block_timestamp = event.timestamp.as_u64();
 
-        info!("Processing block {} at {}", event.number, event.timestamp,);
+        info!("Processing block {} at {}", event.number, event.timestamp);
         self.handle_fills()
             .await
             .map_err(|e| error!("Error handling fills {}", e))
@@ -342,12 +342,7 @@ impl<M: Middleware + 'static> UniswapXPriorityFill<M> {
         })
     }
 
-    fn update_order_state(
-        &mut self,
-        order: PriorityOrder,
-        signature: String,
-        order_hash: String,
-    ) {
+    fn update_order_state(&mut self, order: PriorityOrder, signature: String, order_hash: String) {
         let resolved = order.resolve(
             self.last_block_number,
             self.last_block_timestamp + BLOCK_TIME,

--- a/src/strategies/priority_strategy.rs
+++ b/src/strategies/priority_strategy.rs
@@ -445,7 +445,7 @@ impl<M: Middleware + 'static> UniswapXPriorityFill<M> {
         self.remove_open_order(order_hash);
         if !self.done_orders.contains_key(order_hash) {
             self.done_orders
-                .insert(order_hash.to_string(), self.last_block_number + DONE_EXPIRY);
+                .insert(order_hash.to_string(), self.last_block_timestamp + DONE_EXPIRY);
         }
     }
 }


### PR DESCRIPTION
so that we don't keep submitting the same order over and over again

chatgpt suggested this https://github.com/xacrimon/dashmap as a more ergonomic replacement of `RwLock<HashMap<..>>`