### PR TITLE
feat: new queued executor to fix concurrency problem

### DIFF
--- a/src/executors/mod.rs
+++ b/src/executors/mod.rs
@@ -1,3 +1,4 @@
 pub mod protect_executor;
 pub mod public_1559_executor;
+pub mod queued_executor;
 pub mod reactor_error_code;

--- a/src/executors/public_1559_executor.rs
+++ b/src/executors/public_1559_executor.rs
@@ -105,8 +105,13 @@ where
             Ok(gas) => gas,
             Err(e) => {
                 // Release the key before returning
-                if let Err(release_err) = self.key_store.release_key(public_address.clone()).await {
-                    warn!("{} - Failed to release key: {}", order_hash, release_err);
+                match self.key_store.release_key(public_address.clone()).await {
+                    Ok(_) => {
+                        info!("{} - Released key: {}", order_hash, public_address);
+                    }
+                    Err(release_err) => {
+                        warn!("{} - Failed to release key: {}", order_hash, release_err);
+                    }
                 }
                 return Err(e);
             }

--- a/src/executors/queued_executor.rs
+++ b/src/executors/queued_executor.rs
@@ -1,0 +1,47 @@
+use crate::executors::public_1559_executor::Public1559Executor;
+use crate::strategies::keystore::KeyStore;
+use crate::strategies::types::SubmitTxToMempoolWithExecutionMetadata;
+use artemis_core::types::Executor;
+use async_trait::async_trait;
+use ethers::providers::Middleware;
+use std::sync::Arc;
+
+pub struct QueuedExecutor<M: Middleware + 'static, N: Middleware + 'static> {
+    provider: Arc<M>,
+    sender_client: Arc<N>,
+    key_store: Arc<KeyStore>,
+}
+
+impl<M: Middleware + 'static, N: Middleware + 'static> QueuedExecutor<M, N> {
+    pub fn new(provider: Arc<M>, sender_client: Arc<N>, key_store: Arc<KeyStore>) -> Self {
+        Self {
+            provider,
+            sender_client,
+            key_store,
+        }
+    }
+}
+
+#[async_trait]
+impl<M, N> Executor<SubmitTxToMempoolWithExecutionMetadata> for QueuedExecutor<M, N>
+where
+    M: Middleware + 'static,
+    M::Error: 'static,
+    N: Middleware + 'static,
+    N::Error: 'static,
+{
+    async fn execute(
+        &self,
+        action: SubmitTxToMempoolWithExecutionMetadata,
+    ) -> Result<(), anyhow::Error> {
+        let public_executor = Public1559Executor::<M, N>::new(
+            self.provider.clone(),
+            self.sender_client.clone(),
+            self.key_store.clone(),
+        );
+
+        tokio::spawn(async move { public_executor.execute(action).await });
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
```
2024-09-12T21:08:12.179092Z  INFO 0x95e06254d1e6652c350b0dce582e8b951a4e753eb1856b8e0b3907cbea862a7a - Routing order, token in: 0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913, token out: 0x50c5725949A6F0c72E6C4a641F24049A917DB0Cb
2024-09-12T21:08:12.247705Z  INFO 0xdccfb1984fee3fb1987760df7dae02e67c1fb3829efb1d6e690b19a105196af4 - Sending trade: num trades: 1 routed quote: 58284549682323539, batch needs: 57990975267072091
2024-09-12T21:08:12.248203Z  INFO 0xc96e190d8fe568ed6be11f1641808fdd9310368938155b54d3afa33da883c6e1 - Acquired key: 0x32f4B2e69EbD7746596AF8699DAC1908F43107aD
2024-09-12T21:08:12.330987Z  INFO 0xc96e190d8fe568ed6be11f1641808fdd9310368938155b54d3afa33da883c6e1 - Executing tx from 0x32f4b2e69ebd7746596af8699dac1908f43107ad
2024-09-12T21:08:12.352071Z  INFO 0xdccfb1984fee3fb1987760df7dae02e67c1fb3829efb1d6e690b19a105196af4 - Acquired key: 0x7fDA166B6970181AB45366Fc3C33B4491c8d1c5a
2024-09-12T21:08:12.460167Z  INFO 0xdccfb1984fee3fb1987760df7dae02e67c1fb3829efb1d6e690b19a105196af4 - Executing tx from 0x7fda166b6970181ab45366fc3c33b4491c8d1c5a
```