### PR TITLE
feat: bot balance tracking

### DIFF
--- a/src/aws_utils/cloudwatch_utils.rs
+++ b/src/aws_utils/cloudwatch_utils.rs
@@ -55,6 +55,9 @@ pub enum CwMetrics {
     TxReverted,
     TxSubmitted,
     TxStatusUnknown,
+
+    /// Balance for individual address
+    Balance(String),
 }
 impl From<CwMetrics> for String {
     fn from(metric: CwMetrics) -> Self {
@@ -63,6 +66,7 @@ impl From<CwMetrics> for String {
             CwMetrics::TxReverted => TX_REVERTED_METRIC.to_string(),
             CwMetrics::TxSubmitted => TX_SUBMITTED_METRIC.to_string(),
             CwMetrics::TxStatusUnknown => TX_STATUS_UNKNOWN_METRIC.to_string(),
+            CwMetrics::Balance(val) => format!("Bal-{}", val),
         }
     }
 }
@@ -77,12 +81,20 @@ pub struct MetricBuilder {
     value: f64,
 }
 
+// TODO: TxStatus type metrics => TxStatus(u32)
 impl MetricBuilder {
     pub fn new(metric: CwMetrics) -> Self {
-        Self {
-            metric_name: metric.into(),
-            dimensions: Vec::new(),
-            value: 1.0,
+        match metric {
+            CwMetrics::Balance(val) => Self {
+                metric_name: format!("Bal-{}", val),
+                dimensions: Vec::new(),
+                value: 0.0,
+            },
+            _ => Self {
+                metric_name: metric.into(),
+                dimensions: Vec::new(),
+                value: 1.0,
+            },
         }
     }
 

--- a/src/executors/public_1559_executor.rs
+++ b/src/executors/public_1559_executor.rs
@@ -260,6 +260,8 @@ where
                     .get_balance(address, Some(block_number.into()))
                     .await
                     .map_or_else(|_| None, |v| Some(format_units(v, "ether").unwrap()));
+                
+                info!("{}- balance: {} at block {}", order_hash, balance_eth.clone().unwrap(), block_number.as_u64());
 
                 // TODO: use if-let chains when it becomes stable https://github.com/rust-lang/rust/issues/53667
                 // if let Some(balance_eth) = balance_eth && let Some(cw) = &self.cloudwatch_client {

--- a/src/executors/public_1559_executor.rs
+++ b/src/executors/public_1559_executor.rs
@@ -261,11 +261,10 @@ where
                     .await
                     .map_or_else(|_| None, |v| Some(format_units(v, "ether").unwrap()));
                 
-                info!("{}- balance: {} at block {}", order_hash, balance_eth.clone().unwrap(), block_number.as_u64());
-
                 // TODO: use if-let chains when it becomes stable https://github.com/rust-lang/rust/issues/53667
                 // if let Some(balance_eth) = balance_eth && let Some(cw) = &self.cloudwatch_client {
                 if let Some(balance_eth) = balance_eth {
+                    info!("{}- balance: {} at block {}", order_hash, balance_eth.clone(), block_number.as_u64());
                     if let Some(cw) = &self.cloudwatch_client {
                         cw.put_metric_data()
                             .namespace(ARTEMIS_NAMESPACE)

--- a/src/executors/public_1559_executor.rs
+++ b/src/executors/public_1559_executor.rs
@@ -260,13 +260,19 @@ where
                     .get_balance(address, Some(block_number.into()))
                     .await
                     .map_or_else(|_| None, |v| Some(format_units(v, "ether").unwrap()));
-                
+
                 // TODO: use if-let chains when it becomes stable https://github.com/rust-lang/rust/issues/53667
                 // if let Some(balance_eth) = balance_eth && let Some(cw) = &self.cloudwatch_client {
                 if let Some(balance_eth) = balance_eth {
-                    info!("{}- balance: {} at block {}", order_hash, balance_eth.clone(), block_number.as_u64());
+                    info!(
+                        "{}- balance: {} at block {}",
+                        order_hash,
+                        balance_eth.clone(),
+                        block_number.as_u64()
+                    );
                     if let Some(cw) = &self.cloudwatch_client {
-                        let metric_future = cw.put_metric_data()
+                        let metric_future = cw
+                            .put_metric_data()
                             .namespace(ARTEMIS_NAMESPACE)
                             .metric_data(
                                 MetricBuilder::new(CwMetrics::Balance(address.to_string()))

--- a/src/executors/public_1559_executor.rs
+++ b/src/executors/public_1559_executor.rs
@@ -10,7 +10,8 @@ use ethers::{
     middleware::MiddlewareBuilder,
     providers::{Middleware, MiddlewareError},
     signers::{LocalWallet, Signer},
-    types::U256,
+    types::{TransactionReceipt, U256},
+    utils::format_units,
 };
 
 use crate::{
@@ -195,7 +196,7 @@ where
         let result = signer.send_transaction(action.execution.tx, None).await;
 
         // Block on pending transaction getting confirmations
-        match result {
+        let (receipt, status) = match result {
             Ok(tx) => {
                 let receipt = tx
                     .confirmations(1)
@@ -209,28 +210,13 @@ where
                     "{} - receipt: tx_hash: {:?}, status: {}",
                     order_hash, receipt.transaction_hash, status,
                 );
-                if let Some(cw) = &self.cloudwatch_client {
-                    let metric_future = cw
-                        .put_metric_data()
-                        .namespace(ARTEMIS_NAMESPACE)
-                        .metric_data(
-                            MetricBuilder::new(receipt_status_to_metric(status.as_u64()))
-                                .add_dimension(
-                                    DimensionName::Executor.as_ref(),
-                                    DimensionValue::PriorityExecutor.as_ref(),
-                                )
-                                .with_value(1.0)
-                                .build(),
-                        )
-                        .send();
-
-                    send_metric_with_order_hash!(&order_hash, metric_future);
-                }
+                (Some(receipt), status)
             }
             Err(e) => {
                 warn!("{} - Error sending transaction: {}", order_hash, e);
+                (None, ethers::types::U64::zero())
             }
-        }
+        };
 
         // regardless of outcome, ensure we release the key
         match self.key_store.release_key(public_address.clone()).await {
@@ -241,6 +227,62 @@ where
                 info!("{} - Failed to release key: {}", order_hash, e);
             }
         }
+
+        // post key-release processing
+        // TODO: parse revert reason
+        if let Some(cw) = &self.cloudwatch_client {
+            let metric_future = cw
+                .put_metric_data()
+                .namespace(ARTEMIS_NAMESPACE)
+                .metric_data(
+                    MetricBuilder::new(receipt_status_to_metric(status.as_u64()))
+                        .add_dimension(
+                            DimensionName::Executor.as_ref(),
+                            DimensionValue::PriorityExecutor.as_ref(),
+                        )
+                        .with_value(1.0)
+                        .build(),
+                )
+                .send();
+
+            send_metric_with_order_hash!(&order_hash, metric_future);
+        }
+
+        if let Some(TransactionReceipt {
+            block_number: Some(block_number),
+            ..
+        }) = receipt
+        {
+            // log wallet balance every 100 blocks
+            if block_number.as_u64() % 100 == 0 {
+                let balance_eth = self
+                    .client
+                    .get_balance(address, Some(block_number.into()))
+                    .await
+                    .map_or_else(|_| None, |v| Some(format_units(v, "ether").unwrap()));
+
+                // TODO: use if-let chains when it becomes stable https://github.com/rust-lang/rust/issues/53667
+                // if let Some(balance_eth) = balance_eth && let Some(cw) = &self.cloudwatch_client {
+                if let Some(balance_eth) = balance_eth {
+                    if let Some(cw) = &self.cloudwatch_client {
+                        cw.put_metric_data()
+                            .namespace(ARTEMIS_NAMESPACE)
+                            .metric_data(
+                                MetricBuilder::new(CwMetrics::Balance(address.to_string()))
+                                    .add_dimension(
+                                        DimensionName::Executor.as_ref(),
+                                        DimensionValue::PriorityExecutor.as_ref(),
+                                    )
+                                    .with_value(balance_eth.parse::<f64>().unwrap_or(0.0))
+                                    .build(),
+                            )
+                            .send()
+                            .await?;
+                    }
+                }
+            }
+        }
+
         Ok(())
     }
 }


### PR DESCRIPTION
checks filler balance every 100 blocks and send a cloudwatch metric

later we can try to implement some rebalancing/top-up from within the bot itself it we want to