### PR TITLE
fix: remove block number check

### DIFF
--- a/src/executors/public_1559_executor.rs
+++ b/src/executors/public_1559_executor.rs
@@ -253,8 +253,6 @@ where
             ..
         }) = receipt
         {
-            // log wallet balance every 100 blocks
-            if block_number.as_u64() % 100 == 0 {
                 let balance_eth = self
                     .client
                     .get_balance(address, Some(block_number.into()))
@@ -289,7 +287,6 @@ where
                                 warn!("{} - error sending metric: {:?}", order_hash, e);
                             }
                         });
-                    }
                 }
             }
         }


### PR DESCRIPTION
since the executor runs on an unpredictable schedule, it could be quite a while before block_number % 100 == 0 to be true 