### PR TITLE
fix: retrying block rpc connection 

### DIFF
--- a/src/aws_utils/cloudwatch_utils.rs
+++ b/src/aws_utils/cloudwatch_utils.rs
@@ -86,7 +86,7 @@ impl MetricBuilder {
     pub fn new(metric: CwMetrics) -> Self {
         match metric {
             CwMetrics::Balance(val) => Self {
-                metric_name: format!("Bal-{:?}", val),
+                metric_name: format!("Bal-{}", val),
                 dimensions: Vec::new(),
                 value: 0.0,
             },

--- a/src/aws_utils/cloudwatch_utils.rs
+++ b/src/aws_utils/cloudwatch_utils.rs
@@ -86,7 +86,7 @@ impl MetricBuilder {
     pub fn new(metric: CwMetrics) -> Self {
         match metric {
             CwMetrics::Balance(val) => Self {
-                metric_name: format!("Bal-{}", val),
+                metric_name: format!("Bal-{:?}", val),
                 dimensions: Vec::new(),
                 value: 0.0,
             },

--- a/src/collectors/block_collector.rs
+++ b/src/collectors/block_collector.rs
@@ -6,7 +6,7 @@ use ethers::{
     providers::PubsubClient,
     types::{H256, U256, U64},
 };
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 use tokio_stream::StreamExt;
 
 /// A collector that listens for new blocks, and generates a stream of
@@ -27,10 +27,16 @@ impl<M> BlockCollector<M> {
     pub fn new(provider: Arc<M>) -> Self {
         Self { provider }
     }
+
+    async fn exponential_backoff(attempt: u32) {
+        let delay = std::cmp::min(2u64.pow(attempt) * 100, 2_000); // Max delay of 2 seconds
+        tokio::time::sleep(Duration::from_millis(delay)).await;
+    }
 }
 
 /// Implementation of the [Collector](Collector) trait for the [BlockCollector](BlockCollector).
 /// This implementation uses the [PubsubClient](PubsubClient) to subscribe to new blocks.
+/// Event stream will try to reconnect to the WSS connection with rpc node in case it's closed for unexpected reasons.
 #[async_trait]
 impl<M> Collector<NewBlock> for BlockCollector<M>
 where
@@ -39,15 +45,33 @@ where
     M::Error: 'static,
 {
     async fn get_event_stream(&self) -> Result<CollectorStream<'_, NewBlock>> {
-        let stream = self.provider.subscribe_blocks().await?;
-        let stream = stream.filter_map(|block| match block.hash {
-            Some(hash) => block.number.map(|number| NewBlock {
-                hash,
-                number,
-                timestamp: block.timestamp,
-            }),
-            None => None,
-        });
+        let stream = async_stream::stream! {
+            let mut attempt = 0;
+            loop {
+                match self.provider.subscribe_blocks().await {
+                    Ok(mut stream) => {
+                        tracing::info!("Successfully subscribed to new blocks stream");
+                        while let Some(block)= stream.next().await {
+                            if let (Some(hash), Some(number)) = (block.hash, block.number) {
+                                yield NewBlock {
+                                    hash,
+                                    number,
+                                    timestamp: block.timestamp,
+                                };
+                            } else {
+                                tracing::warn!("Received block with missing hash or number: {:?}", block);
+                            }
+                        }
+                        tracing::error!("New block stream ended unexpectedly");
+                    }
+                    Err(e) => {
+                        tracing::error!("Failed to subscribe to new blocks: {:?}", e);
+                        Self::exponential_backoff(attempt).await;
+                        attempt += 1;
+                    }
+                }
+            }
+        };
         Ok(Box::pin(stream))
     }
 }

--- a/src/executors/public_1559_executor.rs
+++ b/src/executors/public_1559_executor.rs
@@ -7,7 +7,12 @@ use artemis_core::types::Executor;
 use async_trait::async_trait;
 use aws_sdk_cloudwatch::Client as CloudWatchClient;
 use ethers::{
-    abi::AbiEncode, middleware::MiddlewareBuilder, providers::{Middleware, MiddlewareError}, signers::{LocalWallet, Signer}, types::{TransactionReceipt, U256}, utils::format_units
+    abi::AbiEncode,
+    middleware::MiddlewareBuilder,
+    providers::{Middleware, MiddlewareError},
+    signers::{LocalWallet, Signer},
+    types::{TransactionReceipt, U256},
+    utils::format_units,
 };
 
 use crate::{


### PR DESCRIPTION
We noticed that the block collector would suddenly panic/exit, but the bot would keep running with the stale block number so no new orders would be filled.