### PR TITLE
fix: better order dedup

### DIFF
--- a/crates/uniswapx-rs/src/order.rs
+++ b/crates/uniswapx-rs/src/order.rs
@@ -125,7 +125,7 @@ pub enum OrderResolution {
     Resolved(ResolvedOrder),
     Expired,
     Invalid,
-    NotFillableYet
+    NotFillableYet(ResolvedOrder),
 }
 
 impl V2DutchOrder {
@@ -213,7 +213,7 @@ impl PriorityOrder {
             .collect();
 
         if Uint::from(block_number).lt(&self.cosignerData.auctionTargetBlock.saturating_sub(Uint::from(2))) {
-            return OrderResolution::NotFillableYet;
+            return OrderResolution::NotFillableYet(ResolvedOrder { input, outputs });
         };
 
         OrderResolution::Resolved(ResolvedOrder { input, outputs })

--- a/src/strategies/types.rs
+++ b/src/strategies/types.rs
@@ -44,6 +44,6 @@ pub struct TokenInTokenOut {
 #[derive(Debug, Clone)]
 pub enum OrderStatus {
     Open(ResolvedOrder),
-    NotFillableYet,
+    NotFillableYet(ResolvedOrder),
     Done,
 }


### PR DESCRIPTION
only insert new orders into `self.open_orders` if they are not immediately executable