### PR TITLE
feat: Refactor order management

### DIFF
--- a/crates/uniswapx-rs/src/order.rs
+++ b/crates/uniswapx-rs/src/order.rs
@@ -125,7 +125,7 @@ pub enum OrderResolution {
     Resolved(ResolvedOrder),
     Expired,
     Invalid,
-    NotFillableYet
+    NotFillableYet(ResolvedOrder),
 }
 
 impl V2DutchOrder {
@@ -213,7 +213,7 @@ impl PriorityOrder {
             .collect();
 
         if Uint::from(block_number).lt(&self.cosignerData.auctionTargetBlock.saturating_sub(Uint::from(2))) {
-            return OrderResolution::NotFillableYet;
+            return OrderResolution::NotFillableYet(ResolvedOrder { input, outputs });
         };
 
         OrderResolution::Resolved(ResolvedOrder { input, outputs })

--- a/src/strategies/types.rs
+++ b/src/strategies/types.rs
@@ -44,6 +44,6 @@ pub struct TokenInTokenOut {
 #[derive(Debug, Clone)]
 pub enum OrderStatus {
     Open(ResolvedOrder),
-    NotFillableYet,
+    NotFillableYet(ResolvedOrder),
     Done,
 }


### PR DESCRIPTION
Adding another dashmap processing_orders to further dedup orders already in our system. Now every new order gets one shot for routing+execution, unless batch_sender fails to send order to RouteCollector , in which case we move the order back to new_orders from processing_orders

Running this locally, the log suggests that we no longer try new orders multiple times anymore