### PR TITLE
fix:use http rpc client 

### DIFF
--- a/src/collectors/block_collector.rs
+++ b/src/collectors/block_collector.rs
@@ -45,7 +45,7 @@ where
             .watch_blocks()
             .await
             .unwrap()
-            .interval(Duration::from_millis(500))
+            .interval(Duration::from_millis(200))
             .stream();
         let stream = async_stream::stream! {
             loop {

--- a/src/collectors/block_collector.rs
+++ b/src/collectors/block_collector.rs
@@ -9,6 +9,8 @@ use ethers::{
 use std::{sync::Arc, time::Duration};
 use tokio_stream::StreamExt;
 
+const BLOCK_POLLING_INTERVAL: Duration = Duration::from_millis(200);
+
 /// A collector that listens for new blocks, and generates a stream of
 /// [events](NewBlock) which contain the block number and hash.
 pub struct BlockCollector<M> {
@@ -45,7 +47,7 @@ where
             .watch_blocks()
             .await
             .unwrap()
-            .interval(Duration::from_millis(200))
+            .interval(BLOCK_POLLING_INTERVAL)
             .stream();
         let stream = async_stream::stream! {
             loop {


### PR DESCRIPTION
Unfortunately ether.rs implementation of the Websocket transport has a bug where if the connection is closed it won't try to reconnect (https://github.com/gakonst/ethers-rs/issues/2323). Given ethers is deprecated in favor of alloy (which also has this bug 😆 but at least there is a workaround: https://github.com/alloy-rs/alloy/issues/690), I don't see it gets fixed ever. In practice, our program always runs into a dead state in less than 24 hours because of this.

This fix performs a lot more rpc calls but it's what it is. We should consider migrating to alloy, but that requires artemis itself to migrate to alloy first 😓 