### PR TITLE
fix: block watcher error handling

### DIFF
--- a/src/collectors/block_collector.rs
+++ b/src/collectors/block_collector.rs
@@ -6,6 +6,7 @@ use ethers::{
     providers::JsonRpcClient,
     types::{H256, U256, U64},
 };
+use tracing::{error, info, warn};
 use std::{sync::Arc, time::Duration};
 use tokio_stream::StreamExt;
 
@@ -32,37 +33,83 @@ impl<M> BlockCollector<M> {
 }
 
 /// Implementation of the [Collector](Collector) trait for the [BlockCollector](BlockCollector).
-/// This implementation uses the [PubsubClient](PubsubClient) to subscribe to new blocks.
-/// Event stream will try to reconnect to the WSS connection with rpc node in case it's closed for unexpected reasons.
+/// This implementation uses polling to subscribe to new blocks.
+/// It handles errors by recreating the filter when necessary.
 #[async_trait]
 impl<M> Collector<NewBlock> for BlockCollector<M>
 where
-    M: Middleware,
-    M::Provider: JsonRpcClient,
-    M::Error: 'static,
+    M: Middleware + Send + Sync,
+    M::Provider: JsonRpcClient + Send + Sync,
+    M::Error: std::fmt::Display + 'static,
 {
     async fn get_event_stream(&self) -> Result<CollectorStream<'_, NewBlock>> {
-        let mut watcher = self
-            .provider
-            .watch_blocks()
-            .await
-            .unwrap()
-            .interval(BLOCK_POLLING_INTERVAL)
-            .stream();
+        // Initial block number to start tracking from
+        let start_block = match self.provider.get_block_number().await {
+            Ok(num) => num.as_u64(),
+            Err(e) => {
+                error!("Failed to get initial block number: {}", e);
+                return Err(e.into());
+            }
+        };
+
+        info!("Starting BlockCollector from block number: {}", start_block);
+
+        let provider = self.provider.clone();
+        let polling_interval = BLOCK_POLLING_INTERVAL;
+
         let stream = async_stream::stream! {
+            let mut last_block = start_block;
+
             loop {
-                if let Some(block_hash) = watcher.next().await {
-                    match self.provider.get_block(block_hash).await {
-                        Ok(Some(block)) => {
-                            yield NewBlock {
-                                hash: block.hash.unwrap(),
-                                number: block.number.unwrap(),
-                                timestamp: block.timestamp,
-                            };
+                // Attempt to watch new blocks
+                let mut watcher = match provider.watch_blocks().await {
+                    Ok(w) => {
+                        info!("Successfully created new block watcher.");
+                        w.interval(polling_interval).stream()
+                    },
+                    Err(e) => {
+                        error!("Failed to create block watcher: {}. Retrying in 5 seconds...", e);
+                        tokio::time::sleep(Duration::from_millis(100)).await;
+                        continue;
+                    }
+                };
+
+                // Iterate over incoming block hashes
+                loop {
+                    match watcher.next().await {
+                        Some(block_hash) => {
+                            match provider.get_block(block_hash).await {
+                                Ok(Some(block)) => {
+                                    let block_number = block.number.unwrap().as_u64();
+                                    let block_timestamp = block.timestamp;
+                                    
+                                    // Update last processed block number
+                                    if block_number > last_block {
+                                        last_block = block_number;
+                                        
+                                        yield NewBlock {
+                                            hash: block.hash.unwrap(),
+                                            number: U64::from(block_number),
+                                            timestamp: block_timestamp,
+                                        };
+                                    }
+                                },
+                                Ok(None) => {
+                                    warn!("Received block hash {} but block not found.", block_hash);
+                                },
+                                Err(e) => {
+                                    error!("Error fetching block {}: {}.", block_hash, e);
+                                }
+                            }
+                        },
+                        None => {
+                            warn!("Block watcher stream ended unexpectedly. Recreating watcher...");
+                            break; // Break inner loop to recreate watcher
                         }
-                        _ => continue,
                     }
                 }
+                // Delay before attempting to recreate the watcher to prevent tight loops
+                tokio::time::sleep(Duration::from_millis(100)).await;
             }
         };
 


### PR DESCRIPTION
provider.watch_blocks() uses eth_getFilterChanges internally. We've noticed that alchemy would error out with 'filter not found' within 24 hours of creating the filter (and this is when we constantly poll every 200 ms). We handle the error by re-creating the watcher stream whenever it stops emitting new block.
