### PR TITLE
fix: Simplify block streaming

### DIFF
--- a/src/collectors/block_collector.rs
+++ b/src/collectors/block_collector.rs
@@ -4,7 +4,7 @@ use async_trait::async_trait;
 use ethers::{
     prelude::Middleware,
     providers::JsonRpcClient,
-    types::{H256, U256, U64},
+    types::{BlockNumber, H256, U256, U64},
 };
 use tracing::{error, info, warn};
 use std::{sync::Arc, time::Duration};
@@ -55,64 +55,37 @@ where
         info!("Starting BlockCollector from block number: {}", start_block);
 
         let provider = self.provider.clone();
-        let polling_interval = BLOCK_POLLING_INTERVAL;
-
+        
         let stream = async_stream::stream! {
             let mut last_block = start_block;
 
             loop {
-                // Attempt to watch new blocks
-                let mut watcher = match provider.watch_blocks().await {
-                    Ok(w) => {
-                        info!("Successfully created new block watcher.");
-                        w.interval(polling_interval).stream()
+                match provider.get_block(BlockNumber::Latest).await {
+                    Ok(Some(block)) => {
+                        let block_number = block.number.unwrap().as_u64();
+                        let block_timestamp = block.timestamp;
+                        
+                        // Update last processed block number
+                        if block_number > last_block {
+                            last_block = block_number;
+                            
+                            yield NewBlock {
+                                hash: block.hash.unwrap(),
+                                number: U64::from(block_number),
+                                timestamp: block_timestamp,
+                            };
+                        };
+                    }
+                    Ok(None) => {
+                        warn!("Fetched latest block but it's empty");
                     },
                     Err(e) => {
-                        error!("Failed to create block watcher: {}. Retrying in 5 seconds...", e);
-                        tokio::time::sleep(Duration::from_millis(100)).await;
-                        continue;
-                    }
-                };
-
-                // Iterate over incoming block hashes
-                loop {
-                    match watcher.next().await {
-                        Some(block_hash) => {
-                            match provider.get_block(block_hash).await {
-                                Ok(Some(block)) => {
-                                    let block_number = block.number.unwrap().as_u64();
-                                    let block_timestamp = block.timestamp;
-                                    
-                                    // Update last processed block number
-                                    if block_number > last_block {
-                                        last_block = block_number;
-                                        
-                                        yield NewBlock {
-                                            hash: block.hash.unwrap(),
-                                            number: U64::from(block_number),
-                                            timestamp: block_timestamp,
-                                        };
-                                    }
-                                },
-                                Ok(None) => {
-                                    warn!("Received block hash {} but block not found.", block_hash);
-                                },
-                                Err(e) => {
-                                    error!("Error fetching block {}: {}.", block_hash, e);
-                                }
-                            }
-                        },
-                        None => {
-                            warn!("Block watcher stream ended unexpectedly. Recreating watcher...");
-                            break; // Break inner loop to recreate watcher
-                        }
+                        error!("Error fetching block: {}.", e);
                     }
                 }
-                // Delay before attempting to recreate the watcher to prevent tight loops
-                tokio::time::sleep(Duration::from_millis(100)).await;
             }
         };
-
+        
         Ok(Box::pin(stream))
     }
 }

--- a/src/collectors/block_collector.rs
+++ b/src/collectors/block_collector.rs
@@ -31,7 +31,6 @@ impl<M> BlockCollector<M> {
 
 /// Implementation of the [Collector](Collector) trait for the [BlockCollector](BlockCollector).
 /// This implementation uses polling to subscribe to new blocks.
-/// It handles errors by recreating the filter when necessary.
 #[async_trait]
 impl<M> Collector<NewBlock> for BlockCollector<M>
 where

--- a/src/collectors/block_collector.rs
+++ b/src/collectors/block_collector.rs
@@ -6,11 +6,8 @@ use ethers::{
     providers::JsonRpcClient,
     types::{BlockNumber, H256, U256, U64},
 };
+use std::sync::Arc;
 use tracing::{error, info, warn};
-use std::{sync::Arc, time::Duration};
-use tokio_stream::StreamExt;
-
-const BLOCK_POLLING_INTERVAL: Duration = Duration::from_millis(200);
 
 /// A collector that listens for new blocks, and generates a stream of
 /// [events](NewBlock) which contain the block number and hash.
@@ -55,7 +52,7 @@ where
         info!("Starting BlockCollector from block number: {}", start_block);
 
         let provider = self.provider.clone();
-        
+
         let stream = async_stream::stream! {
             let mut last_block = start_block;
 
@@ -64,11 +61,11 @@ where
                     Ok(Some(block)) => {
                         let block_number = block.number.unwrap().as_u64();
                         let block_timestamp = block.timestamp;
-                        
+
                         // Update last processed block number
                         if block_number > last_block {
                             last_block = block_number;
-                            
+
                             yield NewBlock {
                                 hash: block.hash.unwrap(),
                                 number: U64::from(block_number),
@@ -85,7 +82,7 @@ where
                 }
             }
         };
-        
+
         Ok(Box::pin(stream))
     }
 }

--- a/src/strategies/priority_strategy.rs
+++ b/src/strategies/priority_strategy.rs
@@ -419,10 +419,9 @@ impl<M: Middleware + 'static> UniswapXPriorityFill<M> {
             .address(reactor_address)
             .event("Fill(bytes32,address,address,uint256)");
 
-        let logs = self.client.get_logs(&filter).await
-            .unwrap_or_else(|e| {
-                error!("Failed to get logs: {}", e);
-                Vec::new()
+        let logs = self.client.get_logs(&filter).await.unwrap_or_else(|e| {
+            error!("Failed to get logs: {}", e);
+            Vec::new()
         });
 
         for log in logs {


### PR DESCRIPTION
`provider.watch_blocks()` internally uses eth_getFilterChanges which in practice, when using a public rpc provider, results in unexpected filter not found errors. Default back to using plain ol' get_block() http call until we migrate to alloy