### PR TITLE
fix: resolve priority order 

### DIFF
--- a/crates/uniswapx-rs/src/order.rs
+++ b/crates/uniswapx-rs/src/order.rs
@@ -269,7 +269,8 @@ impl PriorityOrder {
             .map(|output| output.scale(priority_fee))
             .collect();
 
-        if BigUint::from(block_number).lt(&self.cosignerData.auctionTargetBlock.saturating_sub(BigUint::from(2))) {
+        let min_start_block = std::cmp::min(self.cosignerData.auctionTargetBlock, self.auctionStartBlock);
+        if BigUint::from(block_number).lt(&min_start_block.saturating_sub(BigUint::from(2))) {
             return OrderResolution::NotFillableYet(ResolvedOrder { input, outputs });
         };
 


### PR DESCRIPTION
For priority orders, we want to start the processing flow N - 2 blocks, where N is the min block at which the order can be filled onchain. Previously we thought N is just `order.cosignerData.targetBlock` but in fact targetBlock can be larger than startBlock at times. So now we set N to min of those two