### PR TITLE
fix: routing api call

### DIFF
--- a/src/collectors/uniswapx_route_collector.rs
+++ b/src/collectors/uniswapx_route_collector.rs
@@ -6,7 +6,7 @@ use aws_sdk_cloudwatch::{config::http::HttpResponse, error::SdkError, operation:
 use reqwest::header::ORIGIN;
 use serde::{Deserialize, Serialize};
 use tokio::sync::mpsc::{Receiver, Sender};
-use tracing::info;
+use tracing::{error, info};
 use uniswapx_rs::order::{Order, ResolvedOrder};
 
 use artemis_core::types::{Collector, CollectorStream};
@@ -325,7 +325,7 @@ impl Collector<RoutedOrder> for UniswapXRouteCollector {
                             };
                         }
                         Err(e) => {
-                            info!("Failed to route order: {}", e);
+                            error!("{}", e);
                         }
                     }
                 }

--- a/src/collectors/uniswapx_route_collector.rs
+++ b/src/collectors/uniswapx_route_collector.rs
@@ -325,6 +325,7 @@ impl Collector<RoutedOrder> for UniswapXRouteCollector {
                             };
                         }
                         Err(e) => {
+                            // formatting is done in fn route_order
                             error!("{}", e);
                         }
                     }


### PR DESCRIPTION
I noticed that we get `404 no route found` when we don't include `protocols=v2,v3,mixed' in the query params, so adding them as default.

Also improved logging so that we can find relevant logs by searching orderHash