### PR TITLE
fix: bump gas limit

### DIFF
--- a/src/executors/public_1559_executor.rs
+++ b/src/executors/public_1559_executor.rs
@@ -118,11 +118,11 @@ where
                             }
                             Err(anyhow::anyhow!("Order Past Deadline"))
                         }
-                        _ => Ok(U256::from(1_000_000)),
+                        _ => Ok(U256::from(2_000_000)),
                     }
                 } else {
                     warn!("Error estimating gas: {:?}", err);
-                    Ok(U256::from(1_000_000))
+                    Ok(U256::from(2_000_000))
                 }
             });
 


### PR DESCRIPTION
most txs to our executor are reverting due to `out of gas`. Given that we can't really estimate gas we simply have a hard-coded value for now. This PR doubles that amount.