### PR TITLE
fix: bump rust version to lowest required by the dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@
 
 # Want to help us make this template better? Share your feedback here: https://forms.gle/ybq9Krt8jtBL3iCk7
 
-ARG RUST_VERSION=1.80.1
+ARG RUST_VERSION=1.81
 ARG APP_NAME=uniswapx-artemis
 
 ################################################################################


### PR DESCRIPTION
tested with `docker build` locally

```
error: rustc 1.80.1 is not supported by the following packages:
  alloy-dyn-abi@0.8.18 requires rustc 1.81
  alloy-json-abi@0.8.18 requires rustc 1.81
  alloy-primitives@0.8.18 requires rustc 1.81
613
  alloy-sol-macro@0.8.18 requires rustc 1.81
614
  alloy-sol-macro-expander@0.8.18 requires rustc 1.81
615
  alloy-sol-macro-input@0.8.18 requires rustc 1.81
616
  alloy-sol-type-parser@0.8.18 requires rustc 1.81
617
  alloy-sol-types@0.8.18 requires rustc 1.81
618
  aws-sdk-cloudwatch@1.59.0 requires rustc 1.81.0
619
  aws-sdk-secretsmanager@1.57.0 requires rustc 1.81.0
620
  aws-sdk-sso@1.53.0 requires rustc 1.81.0
621
  aws-sdk-ssooidc@1.54.0 requires rustc 1.81.0
622
  aws-sdk-sts@1.54.0 requires rustc 1.81.0
623
  syn-solidity@0.8.18 requires rustc 1.81
```