### PR TITLE
feat: process orders with saved routes at targetBlock-2

### DIFF
--- a/crates/uniswapx-rs/src/order.rs
+++ b/crates/uniswapx-rs/src/order.rs
@@ -255,7 +255,7 @@ impl PriorityOrder {
         PriorityOrder::abi_encode(self)
     }
 
-    pub fn resolve(&self, block_number: u64, timestamp: u64, priority_fee: BigUint, has_calldata: bool) -> OrderResolution {
+    pub fn resolve(&self, block_number: u64, timestamp: u64, priority_fee: BigUint) -> OrderResolution {
         let timestamp = BigUint::from(timestamp);
 
         if self.info.deadline.lt(&timestamp) {
@@ -271,10 +271,7 @@ impl PriorityOrder {
 
         let min_start_block = std::cmp::min(self.cosignerData.auctionTargetBlock, self.auctionStartBlock);
 
-        // If the order already has calldata, we can quickly process it the block before the target block
-        // Otherwise, we need to process it in targetBlock - 2 to give time for the routing-api call (~1 second)
-        let buffer = if has_calldata { 1 } else { 2 };
-        if BigUint::from(block_number).lt(&min_start_block.saturating_sub(BigUint::from(buffer))) {
+        if BigUint::from(block_number).lt(&min_start_block.saturating_sub(BigUint::from(2))) {
             return OrderResolution::NotFillableYet(ResolvedOrder { input, outputs });
         };
 

--- a/src/strategies/priority_strategy.rs
+++ b/src/strategies/priority_strategy.rs
@@ -216,15 +216,11 @@ impl UniswapXPriorityFill {
             .unwrap();
 
         let order_hash = event.order_hash.clone();
-        let has_calldata = event.route.as_ref()
-            .map(|route| !route.method_parameters.calldata.is_empty())
-            .unwrap_or(false);
 
         let resolved_order = order.resolve(
             *self.last_block_number.read().await,
             *self.last_block_timestamp.read().await + BLOCK_TIME,
             Uint::from(0),
-            has_calldata,
         );
 
         let order_status = match resolved_order {
@@ -516,12 +512,10 @@ impl UniswapXPriorityFill {
         signature: &str,
         route: Option<RouteInfo>,
     ) -> Result<()> {
-        let has_calldata = route.as_ref().map(|route| !route.method_parameters.calldata.is_empty()).unwrap_or(false);
         let resolved = order.resolve(
             *self.last_block_number.read().await,
             *self.last_block_timestamp.read().await + BLOCK_TIME,
             Uint::from(0),
-            has_calldata,
         );
         let order_status = match resolved {
             OrderResolution::Expired => OrderStatus::Done,


### PR DESCRIPTION
- Previously had orders with saved routes processed at `targetBlock-1` and orders needing routes at `targetBlock-2`
- This change makes both process at `targetBlock-2`