### PR TITLE
Http RPC option

### DIFF
--- a/src/executors/dutch_executor.rs
+++ b/src/executors/dutch_executor.rs
@@ -24,14 +24,14 @@ use crate::{
 const GAS_LIMIT: u64 = 1_000_000;
 
 /// An executor that sends transactions to the mempool.
-pub struct ProtectExecutor {
+pub struct DutchExecutor {
     client: Arc<DynProvider<AnyNetwork>>,
     sender_client: Arc<DynProvider<AnyNetwork>>,
     key_store: Arc<KeyStore>,
     cloudwatch_client: Option<Arc<CloudWatchClient>>,
 }
 
-impl ProtectExecutor {
+impl DutchExecutor {
     pub fn new(
         client: Arc<DynProvider<AnyNetwork>>,
         sender_client: Arc<DynProvider<AnyNetwork>>,
@@ -48,7 +48,7 @@ impl ProtectExecutor {
 }
 
 #[async_trait]
-impl Executor<SubmitTxToMempool> for ProtectExecutor {
+impl Executor<SubmitTxToMempool> for DutchExecutor {
     /// Send a transaction to the mempool.
     async fn execute(&self, mut action: SubmitTxToMempool) -> Result<()> {
         let chain_id = action

--- a/src/executors/mod.rs
+++ b/src/executors/mod.rs
@@ -1,4 +1,4 @@
-pub mod protect_executor;
-pub mod public_1559_executor;
+pub mod dutch_executor;
+pub mod priority_executor;
 pub mod queued_executor;
 pub mod reactor_error_code;

--- a/src/executors/priority_executor.rs
+++ b/src/executors/priority_executor.rs
@@ -36,7 +36,7 @@ const QUOTE_ETH_LOG10_THRESHOLD: usize = 8;
 const DEFAULT_FALLBACK_BID_SCALE_FACTOR: u64 = 50;
 
 /// An executor that sends transactions to the public mempool.
-pub struct Public1559Executor {
+pub struct PriorityExecutor {
     client: Arc<DynProvider<AnyNetwork>>,
     sender_client: Arc<DynProvider<AnyNetwork>>,
     key_store: Arc<KeyStore>,
@@ -50,7 +50,7 @@ enum TransactionOutcome {
     RetryableFailure,
 }
 
-impl Public1559Executor {
+impl PriorityExecutor {
     pub fn new(
         client: Arc<DynProvider<AnyNetwork>>,
         sender_client: Arc<DynProvider<AnyNetwork>>,
@@ -248,7 +248,7 @@ impl Public1559Executor {
 }
 
 #[async_trait]
-impl Executor<SubmitTxToMempoolWithExecutionMetadata> for Public1559Executor {
+impl Executor<SubmitTxToMempoolWithExecutionMetadata> for PriorityExecutor {
     /// Send a transaction to the mempool.
     async fn execute(&self, mut action: SubmitTxToMempoolWithExecutionMetadata) -> Result<()> {
         info!("{} - Executing transaction", action.metadata.order_hash);
@@ -557,7 +557,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_bids_for_order_small_quote() {
-        let executor = Public1559Executor::new(
+        let executor = PriorityExecutor::new(
             Arc::new(DynProvider::new(MockProvider)),
             Arc::new(DynProvider::new(MockProvider)),
             Arc::new(KeyStore::new()),
@@ -579,7 +579,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_bids_for_order_large_quote() {
-        let executor = Public1559Executor::new(
+        let executor = PriorityExecutor::new(
             Arc::new(DynProvider::new(MockProvider)),
             Arc::new(DynProvider::new(MockProvider)),
             Arc::new(KeyStore::new()),
@@ -600,7 +600,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_bids_for_order_exact_output() {
-        let executor = Public1559Executor::new(
+        let executor = PriorityExecutor::new(
             Arc::new(DynProvider::new(MockProvider)),
             Arc::new(DynProvider::new(MockProvider)),
             Arc::new(KeyStore::new()),
@@ -622,7 +622,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_bids_for_order_no_gas_estimate() {
-        let executor = Public1559Executor::new(
+        let executor = PriorityExecutor::new(
             Arc::new(DynProvider::new(MockProvider)),
             Arc::new(DynProvider::new(MockProvider)),
             Arc::new(KeyStore::new()),
@@ -643,7 +643,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_bids_for_order_too_little_quote() {
-        let executor = Public1559Executor::new(
+        let executor = PriorityExecutor::new(
             Arc::new(DynProvider::new(MockProvider)),
             Arc::new(DynProvider::new(MockProvider)),
             Arc::new(KeyStore::new()),
@@ -664,7 +664,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_extremely_large_quote() {
-        let executor = Public1559Executor::new(
+        let executor = PriorityExecutor::new(
             Arc::new(DynProvider::new(MockProvider)),
             Arc::new(DynProvider::new(MockProvider)),
             Arc::new(KeyStore::new()),

--- a/src/executors/queued_executor.rs
+++ b/src/executors/queued_executor.rs
@@ -1,4 +1,4 @@
-use crate::executors::public_1559_executor::Public1559Executor;
+use crate::executors::priority_executor::PriorityExecutor;
 use crate::strategies::keystore::KeyStore;
 use crate::strategies::types::SubmitTxToMempoolWithExecutionMetadata;
 use alloy::{network::AnyNetwork, providers::DynProvider};
@@ -36,7 +36,7 @@ impl Executor<SubmitTxToMempoolWithExecutionMetadata> for QueuedExecutor {
         &self,
         action: SubmitTxToMempoolWithExecutionMetadata,
     ) -> Result<(), anyhow::Error> {
-        let public_executor = Public1559Executor::new(
+        let public_executor = PriorityExecutor::new(
             self.provider.clone(),
             self.sender_client.clone(),
             self.key_store.clone(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,7 +18,7 @@ use alloy::{
     signers::local::PrivateKeySigner,
     transports::{impl_future, TransportResult},
 };
-use executors::protect_executor::ProtectExecutor;
+use executors::dutch_executor::DutchExecutor;
 use executors::queued_executor::QueuedExecutor;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -311,7 +311,7 @@ async fn main() -> Result<()> {
         _ => None,
     });
 
-    let protect_executor = Box::new(ProtectExecutor::new(
+    let protect_executor = Box::new(DutchExecutor::new(
         wss_provider.clone(),
         sender_client.clone(),
         key_store.clone(),

--- a/src/strategies/priority_strategy.rs
+++ b/src/strategies/priority_strategy.rs
@@ -108,18 +108,12 @@ impl ExecutionMetadata {
             self.quote.saturating_sub(self.amount_required)
         };
 
-        info!("{} - amount_required: {:?}", self.order_hash, self.amount_required);
-        info!("{} - quote: {:?}", self.order_hash, self.quote);
-        info!("{} - profit_quote: {:?}", self.order_hash, profit_quote);
-        info!("{} - bid_bps: {:?}", self.order_hash, bid_bps);
         let mps_of_improvement = profit_quote
             .saturating_mul(U256::from(MPS))
             .checked_div(self.amount_required)?;
-        info!("{} - mps_of_improvement: {:?}", self.order_hash, mps_of_improvement);
         let priority_fee = mps_of_improvement
             .checked_mul(U256::from(bid_bps))?
             .checked_div(U256::from(BPS))?;
-        info!("{} - priority_fee: {:?}", self.order_hash, priority_fee);
         Some(priority_fee)
     }
 


### PR DESCRIPTION
Allow optional `http` endpoint for sender_client.

Rename executors more appropriately.