### PR TITLE
RPC resiliency, nonce burning, more metrics

### DIFF
--- a/src/aws_utils/cloudwatch_utils.rs
+++ b/src/aws_utils/cloudwatch_utils.rs
@@ -20,6 +20,9 @@ pub const ROUTING_MS: &str = "RoutingMs";
 pub const TX_SUCCEEDED_METRIC: &str = "TransactionSucceeded";
 pub const TX_REVERTED_METRIC: &str = "TransactionReverted";
 pub const TX_SUBMITTED_METRIC: &str = "TransactionSubmitted";
+pub const ORDER_RECEIVED_METRIC: &str = "OrderReceived";
+pub const ORDER_BID_METRIC: &str = "OrderBid";
+pub const ORDER_FILLED_METRIC: &str = "OrderFilled";
 pub const TX_STATUS_UNKNOWN_METRIC: &str = "TransactionStatusUnknown";
 pub const LATEST_BLOCK: &str = "LatestBlock";
 pub const EXECUTION_ATTEMPTED_METRIC: &str = "ExecutionAttempted";
@@ -86,6 +89,9 @@ pub enum CwMetrics {
     TxSucceeded(u64),
     TxReverted(u64),
     TxSubmitted(u64),
+    OrderReceived(u64),
+    OrderBid(u64),
+    OrderFilled(u64),
     TxStatusUnknown(u64),
     LatestBlock(u64),
     RevertCode(u64, String), // chain_id and revert code string
@@ -112,6 +118,9 @@ impl From<CwMetrics> for String {
             CwMetrics::TxSucceeded(chain_id) => format!("{}-{}", chain_id, TX_SUCCEEDED_METRIC),
             CwMetrics::TxReverted(chain_id) => format!("{}-{}", chain_id, TX_REVERTED_METRIC),
             CwMetrics::TxSubmitted(chain_id) => format!("{}-{}", chain_id, TX_SUBMITTED_METRIC),
+            CwMetrics::OrderReceived(chain_id) => format!("{}-{}", chain_id, ORDER_RECEIVED_METRIC),
+            CwMetrics::OrderBid(chain_id) => format!("{}-{}", chain_id, ORDER_BID_METRIC),
+            CwMetrics::OrderFilled(chain_id) => format!("{}-{}", chain_id, ORDER_FILLED_METRIC),
             CwMetrics::TxStatusUnknown(chain_id) => {
                 format!("{}-{}", chain_id, TX_STATUS_UNKNOWN_METRIC)
             }

--- a/src/executors/priority_executor.rs
+++ b/src/executors/priority_executor.rs
@@ -34,7 +34,7 @@ static GWEI_PER_ETH: U256 = u256!(1_000_000_000);
 const QUOTE_ETH_LOG10_THRESHOLD: usize = 8;
 // The number of bps to add to the base bid for each fallback bid
 const DEFAULT_FALLBACK_BID_SCALE_FACTOR: u64 = 50;
-const CONFIRMATION_TIMEOUT: u64 = 30;
+const CONFIRMATION_TIMEOUT_SEC: u64 = 10;
 
 /// An executor that sends transactions to the public mempool.
 pub struct PriorityExecutor {
@@ -108,7 +108,7 @@ impl PriorityExecutor {
             Ok(tx) => {
                 info!("{} - Waiting for confirmations", order_hash);
                 let receipt = match tokio::time::timeout(
-                    std::time::Duration::from_secs(CONFIRMATION_TIMEOUT),
+                    std::time::Duration::from_secs(CONFIRMATION_TIMEOUT_SEC),
                     tx.with_required_confirmations(0).get_receipt()
                 ).await {
                     Ok(receipt_result) => receipt_result.map_err(|e| {

--- a/src/main.rs
+++ b/src/main.rs
@@ -293,6 +293,7 @@ async fn main() -> Result<()> {
         OrderType::DutchV3 => {
             let uniswapx_strategy = UniswapXDutchV3Fill::new(
                 client.clone().unwrap(),
+                cloudwatch_client.clone(),
                 config.clone(),
                 batch_sender,
                 route_receiver,

--- a/src/main.rs
+++ b/src/main.rs
@@ -170,10 +170,12 @@ async fn main() -> Result<()> {
         ));
         client = Some(wss_provider.clone());
         sender_client = Some(wss_provider.clone());
+        info!("Using WSS provider: {}", wss);
     }
 
     // Initialize HTTP provider if specified
     if let Some(http_endpoint) = args.http {
+        info!("Using HTTP provider: {}", http_endpoint);
         let http_client = ClientBuilder::default().http(http_endpoint.parse()?);
         let http_provider = Arc::new(DynProvider::<AnyNetwork>::new(
             ProviderBuilder::new()

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -5,7 +5,7 @@ use alloy_primitives::{Address, U256};
 use serde::Deserialize;
 
 const NONCE_BURN_GAS_MULTIPLIER: u128 = 10;
-const NONCE_BURN_PRIORITY_FEE: u128 = 100000; // 0.0001 gwei
+const NONCE_BURN_PRIORITY_FEE: u128 = 1e7 as u128; // 0.01 gwei (max priority bid possible)
 const ETH_TRANSFER_GAS: u64 = 21000;
 
 macro_rules! send_metric_with_order_hash {

--- a/src/strategies/priority_strategy.rs
+++ b/src/strategies/priority_strategy.rs
@@ -297,6 +297,23 @@ impl UniswapXPriorityFill {
             );
             return self.check_orders_for_submission().await;
         }
+        if let Some(cw) = &self.cloudwatch_client {
+            let metric_future = cw
+                .put_metric_data()
+                .namespace(ARTEMIS_NAMESPACE)
+                .metric_data(
+                    MetricBuilder::new(CwMetrics::OrderReceived(self.chain_id))
+                        .add_dimension(DimensionName::Service.as_ref(), DimensionValue::PriorityExecutor.as_ref())
+                        .with_value(1.0)
+                        .build(),
+                )
+                .send();
+            tokio::spawn(async move {
+                if let Err(e) = metric_future.await {
+                    warn!("Error sending order received metric: {:?}", e);
+                }
+            });
+        }
 
         let order = self
             .decode_order(&event.encoded_order)


### PR DESCRIPTION
On Unichain, we see:
1. Keys remaining locked due to long running rpc calls
2. Txs failing due to `replacement transaction underpriced` (aka nonce re-use)

Note, this is not occurring on Base despite using the same logic.

The hypothesis as to why this is happening:
On Unichain, RPC providers experience extreme latency (100-1k blocks of delay). This causes the thread to get stuck waiting for confirmations which never arrive. This prevents the keys from being unlocked. When re-deploying the service, the keys are all unlocked again however the old txs are stuck in the mem-pool. Because the old txs are still stuck in the mempool, the new txs cannot be processed without first burning the nonce.

This PR adds a 10 second timeout to the awaiting confirmation process and a nonce burning method in case the tx submission fails due to `replacement transaction underpriced`.

Bonus: the PR also adds some new order metrics and logs.