### PR TITLE
Handle revert protected chains

### DIFF
--- a/src/executors/priority_executor.rs
+++ b/src/executors/priority_executor.rs
@@ -75,7 +75,7 @@ impl PriorityExecutor {
             let metric = match outcome {
                 Ok(TransactionOutcome::Success(_)) => CwMetrics::TxSucceeded(chain_id),
                 Ok(TransactionOutcome::Failure(_)) | Ok(TransactionOutcome::RetryableFailure) => CwMetrics::TxReverted(chain_id),
-                Err(_) => CwMetrics::TxStatusUnknown(chain_id),
+                Ok(TransactionOutcome::TimedOut(_)) | Err(_) => CwMetrics::TxStatusUnknown(chain_id),
             };
             
             let metric_future = build_metric_future(

--- a/src/main.rs
+++ b/src/main.rs
@@ -91,7 +91,7 @@ pub struct Args {
     #[arg(long, required = true)]
     pub executor_address: String,
 
-    /// Whether to use revert protection for priority orders.
+    /// Whether the chain uses revert protection.
     #[arg(long, required = false)]
     pub revert_protection: bool,
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -91,6 +91,10 @@ pub struct Args {
     #[arg(long, required = true)]
     pub executor_address: String,
 
+    /// Whether to use revert protection for priority orders.
+    #[arg(long, required = false)]
+    pub revert_protection: bool,
+
     /// Order type to use.
     #[arg(long, required = true)]
     pub order_type: OrderType,
@@ -276,6 +280,7 @@ async fn main() -> Result<()> {
         fallback_bid_scale_factor: args.fallback_bid_scale_factor,
         min_block_percentage_buffer: args.min_block_percentage_buffer,
         executor_address: args.executor_address,
+        revert_protection: args.revert_protection,
     };
 
     match &args.order_type {

--- a/src/strategies/types.rs
+++ b/src/strategies/types.rs
@@ -35,6 +35,7 @@ pub struct Config {
     pub executor_address: String,
     pub min_block_percentage_buffer: Option<u64>,
     pub fallback_bid_scale_factor: Option<u64>,
+    pub revert_protection: bool,
 }
 
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]


### PR DESCRIPTION
- Use the same nonce for multiple bids if the chain has revert protection
- If all txs timeout, then burn the nonce so that future use of this wallet won't get the same nonce (and need a replacement tx)
- Remove retry logic 
  - we don't need it as much now that we have accurate block timing
  - unclear how it would work on a revert protected chain
- Update the OrderReceived metric to only increment for new orders