### PR TITLE
feat:add key usage metrics

### DIFF
--- a/src/aws_utils/cloudwatch_utils.rs
+++ b/src/aws_utils/cloudwatch_utils.rs
@@ -31,6 +31,8 @@ pub const EXECUTION_SKIPPED_PAST_DEADLINE_METRIC: &str = "ExecutionSkippedPastDe
 pub const UNPROFITABLE_METRIC: &str = "Unprofitable";
 pub const TARGET_BLOCK_DELTA: &str = "TargetBlockDelta";
 pub const REVERT_CODE_METRIC: &str = "RevertCode";
+pub const KEYS_IN_USE: &str = "KeysInUse";
+pub const KEYS_AVAILABLE: &str = "KeysAvailable";
 
 pub enum DimensionName {
     Service,
@@ -100,6 +102,10 @@ pub enum CwMetrics {
     Balance(String),
     // negative is too early, positive is too late
     TargetBlockDelta(u64),
+    
+    /// Keystore metrics
+    KeysInUse(u64),      // chain_id
+    KeysAvailable(u64),  // chain_id
 }
 impl From<CwMetrics> for String {
     fn from(metric: CwMetrics) -> Self {
@@ -128,6 +134,8 @@ impl From<CwMetrics> for String {
             CwMetrics::LatestBlock(chain_id) => format!("{}-{}", chain_id, LATEST_BLOCK),
             CwMetrics::TargetBlockDelta(chain_id) => format!("{}-{}", chain_id, TARGET_BLOCK_DELTA),
             CwMetrics::RevertCode(chain_id, code) => format!("{}-{}-{}", chain_id, REVERT_CODE_METRIC, code),
+            CwMetrics::KeysInUse(chain_id) => format!("{}-{}", chain_id, KEYS_IN_USE),
+            CwMetrics::KeysAvailable(chain_id) => format!("{}-{}", chain_id, KEYS_AVAILABLE),
         }
     }
 }

--- a/src/executors/priority_executor.rs
+++ b/src/executors/priority_executor.rs
@@ -294,6 +294,29 @@ impl Executor<SubmitTxToMempoolWithExecutionMetadata> for PriorityExecutor {
             if let Some(metric_future) = metric_future {
                 send_metric_with_order_hash!(&order_hash, metric_future);
             }
+            // send keystore metrics in the background
+            let keys_in_use = self.key_store.get_keys_in_use();
+            let keys_available = self.key_store.get_keys_available();
+
+            let keys_in_use_future = build_metric_future(
+                self.cloudwatch_client.clone(),
+                DimensionValue::PriorityExecutor,
+                CwMetrics::KeysInUse(chain_id_u64),
+                keys_in_use as f64,
+            );
+            if let Some(metric_future) = keys_in_use_future {
+                send_metric_with_order_hash!(&order_hash, metric_future);
+            }
+
+            let keys_available_future = build_metric_future(
+                self.cloudwatch_client.clone(),
+                DimensionValue::PriorityExecutor,
+                CwMetrics::KeysAvailable(chain_id_u64),
+                keys_available as f64,
+            );
+            if let Some(metric_future) = keys_available_future {
+                send_metric_with_order_hash!(&order_hash, metric_future);
+            }
 
             // Acquire a key from the key store
             let (addr, private_key) = self


### PR DESCRIPTION
uses atomic usize so that there is no data race between threads