### PR TITLE
Improve documentation and clarify code

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is a sample [Artemis](https://github.com/paradigmxyz/artemis) bot that fill
 
 Feel free to fork and modify to run any strategies you wish to fill UniswapX orders!
 
-# Usage
+## Usage
 
 First you must deploy an executor contract that implements the [IReactorCallback](https://github.com/Uniswap/UniswapX/blob/main/src/interfaces/IReactorCallback.sol) interface. This sample currently uses the provided [SwapRouter02Executor](https://github.com/Uniswap/UniswapX/blob/main/src/sample-executors/SwapRouter02Executor.sol).
 
@@ -12,42 +12,96 @@ Then update the address constant in [uniswapx_strategy](./src/strategies/uniswap
 
 Finally, run the bot with the following command:
 
-```
+```shell
 cargo run -- --http <http RPC url> --mevblocker-http <mevblocker http url> --private-key <private key> --bid-percentage <percent of profit to share as gas> --order-type <Priority|DutchV2|DutchV3> --chain-id <chain id> --executor-address <executor address>
 ```
 
-# Collectors
+## Collectors
+These collectors operate in parallel:
+- [Ethereum block collector](./src/collectors/block_collector.rs) \
+  Collects new blocks as they are confirmed. Similar to the base one in [artemis-core](https://github.com/paradigmxyz/artemis/tree/main/crates/artemis-core), but includes timestamp data to resolve Dutch decays.
+- [UniswapX order collector](./src/collectors/uniswapx_order_collector.rs) \
+  Polls UniswapX API every 250 ms to collect new executable orders as they are posted.
+- [UniswapX route collector](./src/collectors/uniswapx_route_collector.rs) \
+  Finds possible on-chain AMM routes with Uniswap API to fill shortlisted UniswapX orders. The routes are based on Uniswap V2, V3 and V4 liquidity pools.
 
-### [block-collector](./src/collectors/block_collector.rs)
+  Runs in a separate collector thread as these can be slow and would block other processing.
 
-Collects new blocks as they are confirmed. Similar to the base one in Artemis-core but includes timestamp data to resolve dutch decays
+## Supported order types
+Three UniswapX order types are supported. Each comes with its own reactor contract that settles the orders and reverts any trades that do not comply with the swap parameters.
 
-### [uniswapx-order-collector](./src/collectors/uniswapx_order_collector.rs)
+- Dutch auction V2 \
+  Reactor contract: [`V2DutchOrderReactor`](https://github.com/Uniswap/UniswapX/blob/main/src/reactors/V2DutchOrderReactor.sol)
+- Dutch auction V3 \
+  Reactor contract: [`V3DutchOrderReactor`](https://github.com/Uniswap/UniswapX/blob/main/src/reactors/V3DutchOrderReactor.sol)
+- Priority \
+  Reactor contract: [`PriorityOrderReactor`](https://github.com/Uniswap/UniswapX/blob/main/src/reactors/PriorityOrderReactor.sol)
 
-Collects new executable UniswapX orders as they are posted.
+Dutch auctions decay the execution price over time which incentivises fillers to complete orders as early as possible.
 
-### [uniswapx-route-collector](./src/collectors/uniswapx_route_collector.rs)
+The key differences between Dutch V2 and V3 are:
+- V2 measures decay using timestamps vs block numbers in V3
+- V2 uses linear decay vs non-linear in V3 \
+  V3 performs linear interpolation between checkpoints
+- V3 adjusts for a change in the gas amount between signing and filling an order
 
-Finds on-chain AMM routes to fill UniswapX orders. Ran in a separate collector thread as these can be slow and don't want to block other processing.
+The Priority reactor is only available on chains that order transactions by priority fee (`gas price - base fee`). Fillers compete by bidding with gas prices to complete an order.
 
-# Strategies
+## Fill strategies
+For each order type, a different fill strategy is used.
 
-### [uniswapx-strategy](./src/strategies/uniswapx_strategy.rs)
+### Dutch auction V2
+Available only on mainnet.
 
-Simple strategy that batches UniswapX orders together by tokenin/tokenout pair and attempts to fill using Uniswap protocol liquidity
+Steps:
+- Watches UniswapX Dutch V2 orders
+- Evaluates their state based on the block timestamp and order deadline
+- Groups orders into batches by (token_in, token_out)
+- Finds AMM routes using Uniswap protocol liquidity (`UniswapXRouteCollector`)
+- Evaluates profitability of received routes
+- Submits transaction to fill order if profitable
+- Check each block for filled orders which are removed after 5 minutes
 
-# Crates
+Code: [`UniswapXUniswapFill`](./src/strategies/uniswapx_strategy.rs)
+
+### Dutch auction V3
+Available only on Arbitrum.
+
+Compared to Dutch auction V2:
+- Tracks orders that are being executed (`processing_orders`)
+- Evaluates order state, taking into account V3 decay curve
+- Estimates gas for fill transaction
+- Computes breakeven gas price and only bids if profitable
+
+Code: [`UniswapXDutchV3Fill`](./src/strategies/dutchv3_strategy.rs)
+
+### Priority
+Available only on Base.
+
+Compared to Dutch auction V3:
+- Calculates priority fee based on the estimated gas use
+- Determines order status given the current time and the estimated target block time
+- Attempts re-routing failed orders
+- Calculates primary bid and 3 fallback bids based on the quote's magnitude
+- Submits separate transactions for each bid
+
+Code: [`UniswapXPriorityFill`](./src/strategies/priority_strategy.rs)
+
+## Keystore
+To facilitate nonce management, multiple private keys can be supplied with the `--private-key-file` parameter. When performing a transaction, a random key that is currently not in use will be used.
+
+## Crates
 
 ### [uniswapx-rs](./crates/uniswapx-rs)
 
-Library for encoding, decoding, and resolving UniswapX dutch orders
+Library for encoding, decoding, and resolving UniswapX Dutch orders
 
 ### [bindings-uniswapx](./crates/bindings-uniswapx)
 
 Autogenerated forge bindings for UniswapX contracts
 
-# Generating bindings
+## Generating bindings
 
-```
+```shell
 forge bind --root ../UniswapX  --overwrite --alloy # replace UniswapX with the path to the UniswapX repo
 ```

--- a/crates/uniswapx-rs/src/order.rs
+++ b/crates/uniswapx-rs/src/order.rs
@@ -17,14 +17,31 @@ fn current_timestamp_ms() -> u64 {
         .as_millis() as u64
 }
 
+// See UniswapX repository for original definitions:
+//
+// https://github.com/Uniswap/UniswapX/
 sol! {
     #[derive(Debug)]
     struct OrderInfo {
+        // The address of the reactor that this order is targeting
+        // Note that this must be included in every order so the swapper
+        // signature commits to the specific reactor that they trust to fill their order properly
         address reactor;
+
+        // The address of the user which created the order
+        // Note that this must be included so that order hashes are unique by swapper
         address swapper;
+
+        // The nonce of the order, allowing for signature replay protection and cancellation
         uint256 nonce;
+
+        // The timestamp after which this order is no longer valid
         uint256 deadline;
+
+        // Custom validation contract
         address additionalValidationContract;
+
+        // Encoded validation params for additionalValidationContract
         bytes additionalValidationData;
     }
 
@@ -67,6 +84,7 @@ sol! {
     struct PriorityInput {
         address token;
         uint256 amount;
+        // the least input amount to be received per wei of priority fee
         uint256 mpsPerPriorityFeeWei;
     }
 
@@ -74,24 +92,34 @@ sol! {
     struct PriorityOutput {
         address token;
         uint256 amount;
+        // the extra amount of output to be paid per wei of priority fee
         uint256 mpsPerPriorityFeeWei;
         address recipient;
     }
 
     #[derive(Debug)]
     struct PriorityCosignerData {
+        // the block at which the order can be executed (overrides auctionStartBlock)
         uint256 auctionTargetBlock;
     }
 
     #[derive(Debug)]
     struct PriorityOrder {
+        // generic order information
         OrderInfo info;
+        // address which may cosign the order
         address cosigner;
+        // block at which the order can be executed
         uint256 auctionStartBlock;
+        // baseline priority fee for the order, above which additional taxes are applied
         uint256 baselinePriorityFeeWei;
+        // tokens that the swapper will provide when settling the order
         PriorityInput input;
+        // tokens that must be received to satisfy the order
         PriorityOutput[] outputs;
+        // signed over by the cosigner
         PriorityCosignerData cosignerData;
+        // signature from the cosigner over (orderHash || cosignerData)
         bytes cosignature;
     }
 
@@ -129,7 +157,7 @@ sol! {
         uint256 maxAmount;
         uint256 adjustmentPerGweiBaseFee;
     }
-    
+
     #[derive(Debug)]
     struct V3DutchOutput {
         address token;
@@ -141,8 +169,18 @@ sol! {
     }
 }
 
+/// Priority fees are expressed in milli-bips (one thousandth of a basis point)
+///
+/// 1 basis point (bp) = 0.01% = 0.0001
+/// 1 milli-bip = 0.0001 / 1000 = 1e-7
+///
+/// MPS represents scaling factor (1 / 1e-7). Multiplying by it converts a value
+/// to milli-bips.
 pub const MPS: u64 = 1e7 as u64;
+
+/// 100% (10k basis points)
 pub const BPS: U256 = Uint::from_limbs([10000, 0, 0, 0]);
+
 const PACKED_UINT16_ARRAY_LENGTH: usize = 256 / 16;
 
 #[derive(Debug, Clone)]
@@ -172,24 +210,32 @@ impl Order {
     pub fn trade_type(&self) -> TradeType {
         match self {
             Order::V2DutchOrder(order) => {
-                if order.baseOutputs.iter().any(|o| o.startAmount == o.endAmount) {
+                if order
+                    .baseOutputs
+                    .iter()
+                    .any(|o| o.startAmount == o.endAmount)
+                {
                     TradeType::ExactOut
                 } else {
                     TradeType::ExactIn
                 }
             }
             Order::PriorityOrder(order) => {
-                if order.outputs.iter().any(|o| o.mpsPerPriorityFeeWei == U256::from(0)) {
+                if order
+                    .outputs
+                    .iter()
+                    .any(|o| o.mpsPerPriorityFeeWei == U256::from(0))
+                {
                     TradeType::ExactOut
                 } else {
                     TradeType::ExactIn
                 }
             }
             Order::V3DutchOrder(order) => {
-                if order.baseOutputs.iter().any(
-                    |o| o.curve.relativeAmounts.len() == 0 ||
-                    o.curve.relativeAmounts.iter().all(|&x| x.eq(&I256::ZERO))
-                ) {
+                if order.baseOutputs.iter().any(|o| {
+                    o.curve.relativeAmounts.is_empty()
+                        || o.curve.relativeAmounts.iter().all(|&x| x.eq(&I256::ZERO))
+                }) {
                     TradeType::ExactOut
                 } else {
                     TradeType::ExactIn
@@ -273,10 +319,20 @@ impl V2DutchOrder {
                 );
 
                 // add exclusivity override to amount
-                if self.cosignerData.decayStartTime.gt(&timestamp) && !self.cosignerData.exclusiveFiller.is_zero() {
-                    let exclusivity = self.cosignerData.exclusivityOverrideBps.checked_add(BPS).ok_or(anyhow::Error::msg("Overflow in exclusivity calculation"))?;
-                    let exclusivity = exclusivity.checked_mul(amount).ok_or(anyhow::Error::msg("Overflow in exclusivity calculation"))?;
-                    amount = exclusivity.checked_div(BPS).ok_or(anyhow::Error::msg("Division by zero in exclusivity calculation"))?;
+                if self.cosignerData.decayStartTime.gt(&timestamp)
+                    && !self.cosignerData.exclusiveFiller.is_zero()
+                {
+                    let exclusivity = self
+                        .cosignerData
+                        .exclusivityOverrideBps
+                        .checked_add(BPS)
+                        .ok_or(anyhow::Error::msg("Overflow in exclusivity calculation"))?;
+                    let exclusivity = exclusivity
+                        .checked_mul(amount)
+                        .ok_or(anyhow::Error::msg("Overflow in exclusivity calculation"))?;
+                    amount = exclusivity.checked_div(BPS).ok_or(anyhow::Error::msg(
+                        "Division by zero in exclusivity calculation",
+                    ))?;
                 };
 
                 Ok(ResolvedOutput {
@@ -288,17 +344,35 @@ impl V2DutchOrder {
             .collect();
 
         match outputs {
-            Ok(resolved_outputs) => OrderResolution::Resolved(ResolvedOrder { input, outputs: resolved_outputs }),
-            Err(_) => OrderResolution::Invalid
+            Ok(resolved_outputs) => OrderResolution::Resolved(ResolvedOrder {
+                input,
+                outputs: resolved_outputs,
+            }),
+            Err(_) => OrderResolution::Invalid,
         }
     }
 }
 
-// Estimates the target block timestamp based on the current block timestamp and average block time
-pub fn projected_target_block_ms(current_block: u64, target_block: u64, block_timestamp: u64, block_time_ms: u64) -> U256 {
+/// Estimates the target block timestamp in milliseconds based on the current
+/// block timestamp and average block time
+///
+/// * `block_timestamp` - Current block timestamp in seconds
+/// * `block_time_ms` - Chain-specific average block time in milliseconds (see
+///                     [get_block_time_ms]).
+pub fn projected_target_block_ms(
+    current_block: u64,
+    target_block: u64,
+    block_timestamp: u64,
+    block_time_ms: u64,
+) -> U256 {
+    assert!(target_block > current_block);
+
     let blocks_until_target = U256::from(target_block).saturating_sub(U256::from(current_block));
     let time_until_target_ms = blocks_until_target.saturating_mul(U256::from(block_time_ms));
-    U256::from(block_timestamp).saturating_mul(U256::from(1000)).saturating_add(time_until_target_ms)
+
+    U256::from(block_timestamp)
+        .saturating_mul(U256::from(1000))
+        .saturating_add(time_until_target_ms)
 }
 
 impl PriorityOrder {
@@ -310,7 +384,27 @@ impl PriorityOrder {
         PriorityOrder::abi_encode(self)
     }
 
-    pub fn resolve(&self, block_number: u64, block_timestamp: u64, block_time_ms: u64, priority_fee: U256, min_block_percentage_buffer: u64) -> OrderResolution {
+    /// Determines fill status based on current time and the estimated target
+    /// block time, and calculates inputs/outputs given the priority fee.
+    ///
+    /// * `block_timestamp` - Current block timestamp in seconds
+    /// * `priority_fee` - Priority fee in wei, may be 0
+    /// * `min_block_percentage_buffer` - Percentage of block time that must
+    ///    elapse before the order becomes fillable. Expressed as value [0, 100].
+    ///
+    /// Returns:
+    /// - `Expired` if completing the order is not possible before deadline
+    /// - `NotFillableYet` if the target block is too far in the future as per
+    ///    min_block_percentage_buffer
+    /// - `ResolvedOrder` otherwise
+    pub fn resolve(
+        &self,
+        block_number: u64,
+        block_timestamp: u64,
+        block_time_ms: u64,
+        priority_fee: U256,
+        min_block_percentage_buffer: u64,
+    ) -> OrderResolution {
         let block_time = block_time_ms / 1000;
         let next_block_timestamp = U256::from(block_timestamp) + U256::from(block_time);
 
@@ -321,21 +415,25 @@ impl PriorityOrder {
             .map(|output| output.scale(priority_fee))
             .collect();
 
-        let min_start_block = std::cmp::min(self.cosignerData.auctionTargetBlock, self.auctionStartBlock);
+        let min_start_block = self
+            .cosignerData
+            .auctionTargetBlock
+            .min(self.auctionStartBlock);
 
         let current_block = U256::from(block_number);
         if self.info.deadline.lt(&next_block_timestamp) || current_block >= min_start_block {
             return OrderResolution::Expired;
         };
-        
+
         // If current timestamp is > BLOCK_TIME away from target
         // then not yet fillable
         let target_block_ms = projected_target_block_ms(
             block_number,
             min_start_block.try_into().unwrap(),
             block_timestamp,
-            block_time_ms
+            block_time_ms,
         );
+
         let time_buffer_ms = block_time_ms * min_block_percentage_buffer / 100;
         if U256::from(current_timestamp_ms() + time_buffer_ms).lt(&target_block_ms) {
             return OrderResolution::NotFillableYet(ResolvedOrder { input, outputs });
@@ -345,9 +443,19 @@ impl PriorityOrder {
     }
 }
 
+/// See https://github.com/Uniswap/UniswapX/blob/3a5bcb6ee628f3336ac2510163eac13ef6dbb03e/src/lib/PriorityFeeLib.sol#L22
 impl PriorityInput {
+    /// scaled_amount = amount * (1 + priority_fee * mpsPerPriorityFeeWei / MPS)
+    /// ->
+    /// scaled_amount = amount * (MPS + priority_fee * mpsPerPriorityFeeWei) / MPS
     pub fn scale(&self, priority_fee: U256) -> ResolvedInput {
-        let amount = self.amount.wrapping_mul(U256::from(MPS).wrapping_add(priority_fee.wrapping_mul(self.mpsPerPriorityFeeWei))).wrapping_div(U256::from(MPS));
+        let amount = self
+            .amount
+            .wrapping_mul(
+                U256::from(MPS).wrapping_add(priority_fee.wrapping_mul(self.mpsPerPriorityFeeWei)),
+            )
+            .wrapping_div(U256::from(MPS));
+
         ResolvedInput {
             token: self.token.to_string(),
             amount,
@@ -355,9 +463,20 @@ impl PriorityInput {
     }
 }
 
+/// See https://github.com/Uniswap/UniswapX/blob/3a5bcb6ee628f3336ac2510163eac13ef6dbb03e/src/lib/PriorityFeeLib.sol#L41
 impl PriorityOutput {
+    /// scaled_amount = amount * (1 - priority_fee * mpsPerPriorityFeeWei / MPS)
+    /// ->
+    /// scaled_amount = amount * (MPS - priority_fee * mpsPerPriorityFeeWei) / MPS
     pub fn scale(&self, priority_fee: U256) -> ResolvedOutput {
-        let amount = self.amount.wrapping_mul(U256::from(MPS).saturating_sub(priority_fee.wrapping_mul(self.mpsPerPriorityFeeWei))).wrapping_div(U256::from(MPS));
+        let amount = self
+            .amount
+            .wrapping_mul(
+                U256::from(MPS)
+                    .saturating_sub(priority_fee.wrapping_mul(self.mpsPerPriorityFeeWei)),
+            )
+            .wrapping_div(U256::from(MPS));
+
         ResolvedOutput {
             token: self.token.to_string(),
             amount,
@@ -391,7 +510,7 @@ impl V3DutchOrder {
                 U256::from(block_number),
                 U256::from(0),
                 self.baseInput.maxAmount,
-                NonlinearDutchDecay::v3_linear_input_decay
+                NonlinearDutchDecay::v3_linear_input_decay,
             ) {
                 Ok(amount) => amount,
                 Err(_) => return OrderResolution::Invalid,
@@ -408,14 +527,27 @@ impl V3DutchOrder {
                     U256::from(block_number),
                     output.minAmount,
                     U256::MAX,
-                    NonlinearDutchDecay::v3_linear_output_decay
+                    NonlinearDutchDecay::v3_linear_output_decay,
                 )?;
-                
-                // add exclusivity override to amount if before decay start block
-                if self.cosignerData.decayStartBlock.gt(&U256::from(block_number)) && !self.cosignerData.exclusiveFiller.is_zero() {
-                    let exclusivity = self.cosignerData.exclusivityOverrideBps.checked_add(BPS).ok_or(anyhow::Error::msg("Overflow in exclusivity calculation"))?;
-                    let exclusivity = exclusivity.checked_mul(amount).ok_or(anyhow::Error::msg("Overflow in exclusivity calculation"))?;
-                    amount = exclusivity.checked_div(BPS).ok_or(anyhow::Error::msg("Division by zero in exclusivity calculation"))?;
+
+                // add exclusivity override to amount before decay start block
+                if self
+                    .cosignerData
+                    .decayStartBlock
+                    .gt(&U256::from(block_number))
+                    && !self.cosignerData.exclusiveFiller.is_zero()
+                {
+                    let exclusivity = self
+                        .cosignerData
+                        .exclusivityOverrideBps
+                        .checked_add(BPS)
+                        .ok_or(anyhow::Error::msg("Overflow in exclusivity calculation"))?;
+                    let exclusivity = exclusivity
+                        .checked_mul(amount)
+                        .ok_or(anyhow::Error::msg("Overflow in exclusivity calculation"))?;
+                    amount = exclusivity.checked_div(BPS).ok_or(anyhow::Error::msg(
+                        "Division by zero in exclusivity calculation",
+                    ))?;
                 };
 
                 Ok(ResolvedOutput {
@@ -427,12 +559,19 @@ impl V3DutchOrder {
             .collect();
 
         match outputs {
-            Ok(resolved_outputs) => OrderResolution::Resolved(ResolvedOrder { input, outputs: resolved_outputs }),
+            Ok(resolved_outputs) => OrderResolution::Resolved(ResolvedOrder {
+                input,
+                outputs: resolved_outputs,
+            }),
             Err(_) => OrderResolution::Invalid,
         }
     }
 }
 
+/// Computes a linear decay between start_amount and end_amount over the
+/// interval [start_time, end_time].
+///
+/// Returns the interpolated amount at the given at_time.
 fn resolve_decay(
     at_time: U256,
     start_time: U256,
@@ -479,7 +618,6 @@ fn resolve_decay(
 }
 
 impl NonlinearDutchDecay {
-
     pub fn decay(
         &self,
         start_amount: U256,
@@ -487,7 +625,7 @@ impl NonlinearDutchDecay {
         block_numberish: U256,
         min_amount: U256,
         max_amount: U256,
-        decay_func: fn(U256, U256, U256, I256, I256) -> Result<I256>
+        decay_func: fn(U256, U256, U256, I256, I256) -> Result<I256>,
     ) -> Result<U256> {
         // Check for invalid decay curve
         if self.relativeAmounts.len() > PACKED_UINT16_ARRAY_LENGTH {
@@ -500,15 +638,14 @@ impl NonlinearDutchDecay {
         }
 
         // Cap block_delta to u16::MAX to prevent overflow
-        let block_delta: u16 = u16::try_from(
-            (block_numberish - decay_start_block).min(U256::from(u16::MAX))
-        )?;
+        let block_delta: u16 =
+            u16::try_from((block_numberish - decay_start_block).min(U256::from(u16::MAX)))?;
 
-        let (start_point, end_point, rel_start_amount, rel_end_amount) = 
+        let (start_point, end_point, rel_start_amount, rel_end_amount) =
             self.locate_curve_position(block_delta)?;
 
         // Calculate decay of only the relative amounts
-        let curve_delta = (decay_func)(
+        let curve_delta = decay_func(
             U256::from(start_point),
             U256::from(end_point),
             U256::from(block_delta),
@@ -549,27 +686,30 @@ impl NonlinearDutchDecay {
         if current_point >= end_point {
             return Ok(end_amount);
         }
+
         let elapsed = current_point.saturating_sub(start_point);
         let duration = end_point.saturating_sub(start_point);
-        let delta: I256;
 
         // Because start_amount + delta is subtracted from the original amount,
         // we want to maximize start_amount + delta to favor the swapper
-        if end_amount < start_amount {
-            delta = -(I256::try_from(
-                U256::try_from(start_amount.checked_sub(end_amount)
-                    .ok_or_else(|| anyhow::anyhow!("Underflow in start_amount - end_amount"))?)?
+        let delta =
+            if end_amount < start_amount {
+                -(I256::try_from(
+                    U256::try_from(start_amount.checked_sub(end_amount).ok_or_else(|| {
+                        anyhow::anyhow!("Underflow in start_amount - end_amount")
+                    })?)?
                     .mul_div_down(elapsed, duration)
-                    .map_err(|e| anyhow::anyhow!("MulDivDown error: {}", e))?
-            )?);
-        } else {
-            delta = I256::try_from(
-                U256::try_from(end_amount.checked_sub(start_amount)
-                .ok_or_else(|| anyhow::anyhow!("Underflow in end_amount - start_amount"))?)?
-                .mul_div_up(elapsed, duration)
-                .map_err(|e| anyhow::anyhow!("MulDivUp error: {}", e))?
-            )?;
-        }
+                    .map_err(|e| anyhow::anyhow!("MulDivDown error: {}", e))?,
+                )?)
+            } else {
+                I256::try_from(
+                    U256::try_from(end_amount.checked_sub(start_amount).ok_or_else(|| {
+                        anyhow::anyhow!("Underflow in end_amount - start_amount")
+                    })?)?
+                    .mul_div_up(elapsed, duration)
+                    .map_err(|e| anyhow::anyhow!("MulDivUp error: {}", e))?,
+                )?
+            };
 
         Ok(start_amount.saturating_add(delta))
     }
@@ -597,26 +737,29 @@ impl NonlinearDutchDecay {
         if current_point >= end_point {
             return Ok(end_amount);
         }
+
         let elapsed = current_point.saturating_sub(start_point);
         let duration = end_point.saturating_sub(start_point);
-        let delta: I256;
 
         // For outputs, we want to minimize start_amount + delta to favor the swapper
-        if end_amount < start_amount {
-            delta = -(I256::try_from(
-                U256::try_from(start_amount.checked_sub(end_amount)
-                    .ok_or_else(|| anyhow::anyhow!("Underflow in start_amount - end_amount"))?)?
+        let delta =
+            if end_amount < start_amount {
+                -(I256::try_from(
+                    U256::try_from(start_amount.checked_sub(end_amount).ok_or_else(|| {
+                        anyhow::anyhow!("Underflow in start_amount - end_amount")
+                    })?)?
                     .mul_div_up(elapsed, duration)
-                    .map_err(|e| anyhow::anyhow!("MulDivUp error: {}", e))?
-            )?);
-        } else {
-            delta = I256::try_from(
-                U256::try_from(end_amount.checked_sub(start_amount)
-                .ok_or_else(|| anyhow::anyhow!("Underflow in end_amount - start_amount"))?)?
-                .mul_div_down(elapsed, duration)
-                .map_err(|e| anyhow::anyhow!("MulDivDown error: {}", e))?
-            )?;
-        }
+                    .map_err(|e| anyhow::anyhow!("MulDivUp error: {}", e))?,
+                )?)
+            } else {
+                I256::try_from(
+                    U256::try_from(end_amount.checked_sub(start_amount).ok_or_else(|| {
+                        anyhow::anyhow!("Underflow in end_amount - start_amount")
+                    })?)?
+                    .mul_div_down(elapsed, duration)
+                    .map_err(|e| anyhow::anyhow!("MulDivDown error: {}", e))?,
+                )?
+            };
 
         Ok(start_amount.saturating_add(delta))
     }
@@ -625,43 +768,45 @@ impl NonlinearDutchDecay {
     fn locate_curve_position(&self, current_relative_block: u16) -> Result<(u16, u16, I256, I256)> {
         // Position is before the start of the curve
         if Self::get_element(self.relativeBlocks, 0)? >= current_relative_block {
-            return Ok((0, Self::get_element(self.relativeBlocks, 0)?, I256::ZERO, self.relativeAmounts[0]));
+            return Ok((
+                0,
+                Self::get_element(self.relativeBlocks, 0)?,
+                I256::ZERO,
+                self.relativeAmounts[0],
+            ));
         }
+
         let last_curve_index = self.relativeAmounts.len() - 1;
         for i in 1..=last_curve_index {
             if Self::get_element(self.relativeBlocks, i)? >= current_relative_block {
-                return Ok(
-                    (
-                        Self::get_element(self.relativeBlocks, i - 1)?,
-                        Self::get_element(self.relativeBlocks, i)?,
-                        self.relativeAmounts[i - 1],
-                        self.relativeAmounts[i],
-                    )
-                );
+                return Ok((
+                    Self::get_element(self.relativeBlocks, i - 1)?,
+                    Self::get_element(self.relativeBlocks, i)?,
+                    self.relativeAmounts[i - 1],
+                    self.relativeAmounts[i],
+                ));
             }
         }
 
-        Ok(
-            (
-                Self::get_element(self.relativeBlocks, last_curve_index)?,
-                Self::get_element(self.relativeBlocks, last_curve_index)?,
-                self.relativeAmounts[last_curve_index],
-                self.relativeAmounts[last_curve_index],
-            )
-        )
+        Ok((
+            Self::get_element(self.relativeBlocks, last_curve_index)?,
+            Self::get_element(self.relativeBlocks, last_curve_index)?,
+            self.relativeAmounts[last_curve_index],
+            self.relativeAmounts[last_curve_index],
+        ))
     }
 
     /// Convert a u16 array into a single Uint<256, 4> value
-    /// 
+    ///
     /// This function packs up to 16 u16 values into a single Uint<256, 4>.
     /// Each u16 value occupies 16 bits in the resulting Uint.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `input_array` - A slice of u16 values to be packed
-    /// 
+    ///
     /// # Returns
-    /// 
+    ///
     /// * `Result<Uint<256, 4>>` - The packed Uint value or an error
     pub fn to_uint16_array(input_array: &[u16]) -> Result<U256> {
         if input_array.len() > PACKED_UINT16_ARRAY_LENGTH {
@@ -678,13 +823,12 @@ impl NonlinearDutchDecay {
         Ok(packed_data)
     }
 
-    
     /// Retrieve the nth uint16 value from a packed uint256
     fn get_element(packed_data: U256, n: usize) -> Result<u16> {
         if n >= PACKED_UINT16_ARRAY_LENGTH {
             return Err(anyhow::Error::msg("IndexOutOfBounds"));
         }
-        
+
         let shift_amount = n * 16;
         let masked_value = (packed_data >> shift_amount) & U256::from(0xFFFF);
         let result = u16::try_from(masked_value)?;
@@ -692,14 +836,13 @@ impl NonlinearDutchDecay {
     }
 }
 
-// tests
 #[cfg(test)]
 mod tests {
     use super::*;
 
     const DECAY_FUNCTIONS: [fn(U256, U256, U256, I256, I256) -> Result<I256>; 2] = [
         NonlinearDutchDecay::v3_linear_input_decay,
-        NonlinearDutchDecay::v3_linear_output_decay
+        NonlinearDutchDecay::v3_linear_output_decay,
     ];
 
     #[test]
@@ -789,13 +932,8 @@ mod tests {
     #[test]
     fn test_nonlinear_decay_before_start() {
         let decay = NonlinearDutchDecay {
-            relativeBlocks: NonlinearDutchDecay::to_uint16_array(&vec![
-                100,
-                200,
-                300,
-                400,
-                500,
-            ]).unwrap(),
+            relativeBlocks: NonlinearDutchDecay::to_uint16_array(&vec![100, 200, 300, 400, 500])
+                .unwrap(),
             relativeAmounts: vec![
                 I256::try_from(1000).unwrap(),
                 I256::try_from(800).unwrap(),
@@ -818,7 +956,7 @@ mod tests {
                 current_block,
                 min_amount,
                 max_amount,
-                *decay_func
+                *decay_func,
             );
             assert_eq!(result.unwrap(), start_amount);
         }
@@ -827,13 +965,8 @@ mod tests {
     #[test]
     fn test_nonlinear_decay_at_start() {
         let decay = NonlinearDutchDecay {
-            relativeBlocks: NonlinearDutchDecay::to_uint16_array(&vec![
-                100,
-                200,
-                300,
-                400,
-                500,
-            ]).unwrap(),
+            relativeBlocks: NonlinearDutchDecay::to_uint16_array(&vec![100, 200, 300, 400, 500])
+                .unwrap(),
             relativeAmounts: vec![
                 I256::try_from(1000).unwrap(),
                 I256::try_from(800).unwrap(),
@@ -856,7 +989,7 @@ mod tests {
                 current_block,
                 min_amount,
                 max_amount,
-                *decay_func
+                *decay_func,
             );
 
             assert_eq!(result.unwrap(), U256::from(1000));
@@ -866,13 +999,8 @@ mod tests {
     #[test]
     fn test_nonlinear_decay_midway() {
         let decay = NonlinearDutchDecay {
-            relativeBlocks: NonlinearDutchDecay::to_uint16_array(&vec![
-                100,
-                200,
-                300,
-                400,
-                500,
-            ]).unwrap(),
+            relativeBlocks: NonlinearDutchDecay::to_uint16_array(&vec![100, 200, 300, 400, 500])
+                .unwrap(),
             relativeAmounts: vec![
                 I256::try_from(1000).unwrap(),
                 I256::try_from(800).unwrap(),
@@ -895,7 +1023,7 @@ mod tests {
                 current_block,
                 min_amount,
                 max_amount,
-                *decay_func
+                *decay_func,
             );
 
             assert_eq!(result.unwrap(), U256::from(100));
@@ -905,13 +1033,8 @@ mod tests {
     #[test]
     fn test_nonlinear_decay_at_end() {
         let decay = NonlinearDutchDecay {
-            relativeBlocks: NonlinearDutchDecay::to_uint16_array(&vec![
-                100,
-                200,
-                300,
-                400,
-                500,
-            ]).unwrap(),
+            relativeBlocks: NonlinearDutchDecay::to_uint16_array(&vec![100, 200, 300, 400, 500])
+                .unwrap(),
             relativeAmounts: vec![
                 I256::try_from(1000).unwrap(),
                 I256::try_from(800).unwrap(),
@@ -934,7 +1057,7 @@ mod tests {
                 current_block,
                 min_amount,
                 max_amount,
-                *decay_func
+                *decay_func,
             );
 
             assert_eq!(result.unwrap(), U256::from(800));
@@ -944,13 +1067,8 @@ mod tests {
     #[test]
     fn test_nonlinear_decay_after_end() {
         let decay = NonlinearDutchDecay {
-            relativeBlocks: NonlinearDutchDecay::to_uint16_array(&vec![
-                100,
-                200,
-                300,
-                400,
-                500,
-            ]).unwrap(),
+            relativeBlocks: NonlinearDutchDecay::to_uint16_array(&vec![100, 200, 300, 400, 500])
+                .unwrap(),
             relativeAmounts: vec![
                 I256::try_from(1000).unwrap(),
                 I256::try_from(800).unwrap(),
@@ -973,22 +1091,17 @@ mod tests {
                 current_block,
                 min_amount,
                 max_amount,
-                *decay_func
+                *decay_func,
             );
-        assert_eq!(result.unwrap(), U256::from(800));
+            assert_eq!(result.unwrap(), U256::from(800));
         }
     }
 
     #[test]
     fn test_nonlinear_decay_with_min_amount() {
         let decay = NonlinearDutchDecay {
-            relativeBlocks: NonlinearDutchDecay::to_uint16_array(&vec![
-                100,
-                200,
-                300,
-                400,
-                500,
-            ]).unwrap(),
+            relativeBlocks: NonlinearDutchDecay::to_uint16_array(&vec![100, 200, 300, 400, 500])
+                .unwrap(),
             relativeAmounts: vec![
                 I256::try_from(1000).unwrap(),
                 I256::try_from(800).unwrap(),
@@ -1011,7 +1124,7 @@ mod tests {
                 current_block,
                 min_amount,
                 max_amount,
-                *decay_func
+                *decay_func,
             );
 
             assert_eq!(result.unwrap(), min_amount);
@@ -1021,13 +1134,8 @@ mod tests {
     #[test]
     fn test_nonlinear_decay_with_max_amount() {
         let decay = NonlinearDutchDecay {
-            relativeBlocks: NonlinearDutchDecay::to_uint16_array(&vec![
-                100,
-                200,
-                300,
-                400,
-                500,
-            ]).unwrap(),
+            relativeBlocks: NonlinearDutchDecay::to_uint16_array(&vec![100, 200, 300, 400, 500])
+                .unwrap(),
             relativeAmounts: vec![
                 I256::try_from(1000).unwrap(),
                 I256::try_from(800).unwrap(),
@@ -1050,7 +1158,7 @@ mod tests {
                 current_block,
                 min_amount,
                 max_amount,
-                *decay_func
+                *decay_func,
             );
             assert_eq!(result.unwrap(), max_amount);
         }
@@ -1060,10 +1168,7 @@ mod tests {
     fn test_nonlinear_decay_start_amount_underflow() {
         let decay = NonlinearDutchDecay {
             relativeBlocks: NonlinearDutchDecay::to_uint16_array(&vec![100, 200]).unwrap(),
-            relativeAmounts: vec![
-                I256::try_from(1000).unwrap(),
-                I256::try_from(800).unwrap(),
-            ],
+            relativeAmounts: vec![I256::try_from(1000).unwrap(), I256::try_from(800).unwrap()],
         };
 
         let start_block = U256::from(1000);
@@ -1079,7 +1184,7 @@ mod tests {
                 current_block,
                 min_amount,
                 max_amount,
-                *decay_func
+                *decay_func,
             );
             // Cannot fall below min_amount, even upon underflow
             assert_eq!(result.unwrap(), min_amount);
@@ -1109,7 +1214,7 @@ mod tests {
                 current_block,
                 min_amount,
                 max_amount,
-                *decay_func
+                *decay_func,
             );
             // Cannot go above max_amount, even upon overflow
             assert_eq!(result.unwrap(), max_amount);
@@ -1120,8 +1225,8 @@ mod tests {
     fn test_nonlinear_decay_relative_blocks_too_long() {
         // Attempt to create the packed relativeBlocks
         let relative_blocks = NonlinearDutchDecay::to_uint16_array(&vec![
-            100, 200, 300, 400, 500, 600, 700, 800, 900, 1000,
-            1100, 1200, 1300, 1400, 1500, 1600, 1700
+            100, 200, 300, 400, 500, 600, 700, 800, 900, 1000, 1100, 1200, 1300, 1400, 1500, 1600,
+            1700,
         ]);
 
         // Ensure that to_uint16_array returned an error due to excessive length
@@ -1152,7 +1257,7 @@ mod tests {
                 current_block,
                 min_amount,
                 max_amount,
-                *decay_func
+                *decay_func,
             );
             assert!(result.is_ok());
             assert_eq!(result.unwrap(), start_amount);

--- a/src/collectors/block_collector.rs
+++ b/src/collectors/block_collector.rs
@@ -2,14 +2,14 @@ use alloy::{
     network::AnyNetwork,
     primitives::{BlockHash, BlockNumber, BlockTimestamp},
     providers::{DynProvider, Provider},
-    rpc::types::eth::{BlockTransactionsKind, BlockNumberOrTag},
+    rpc::types::eth::{BlockNumberOrTag, BlockTransactionsKind},
 };
 use anyhow::Result;
 use artemis_core::types::{Collector, CollectorStream};
 use async_trait::async_trait;
 use std::sync::Arc;
-use tokio_stream::StreamExt;
 use tokio::time::Duration;
+use tokio_stream::StreamExt;
 
 const BLOCK_POLLING_INTERVAL: Duration = Duration::from_secs(1);
 
@@ -43,7 +43,6 @@ impl Collector<NewBlock> for BlockCollector {
         // First try to subscribe to blocks
         match provider.subscribe_blocks().await {
             Ok(sub) => {
-                
                 let stream = sub.into_stream().map(|header| NewBlock {
                     hash: header.hash,
                     number: header.number,
@@ -53,25 +52,33 @@ impl Collector<NewBlock> for BlockCollector {
             }
             Err(_) => {
                 // Fallback to polling
-                let stream = tokio_stream::wrappers::IntervalStream::new(tokio::time::interval(BLOCK_POLLING_INTERVAL))
-                    .then(move |_| {
-                        let provider = provider.clone();
-                        async move {
-                            match provider.get_block_by_number(BlockNumberOrTag::Latest, BlockTransactionsKind::Full).await {
-                                Ok(Some(block)) => {
-                                    let header = &block.header;
-                                    Some(NewBlock {
-                                        hash: header.hash,
-                                        number: header.number,
-                                        timestamp: header.timestamp,
-                                    })
-                                }
-                                Ok(None) => None,
-                                Err(_) => None,
+                let stream = tokio_stream::wrappers::IntervalStream::new(tokio::time::interval(
+                    BLOCK_POLLING_INTERVAL,
+                ))
+                .then(move |_| {
+                    let provider = provider.clone();
+                    async move {
+                        match provider
+                            .get_block_by_number(
+                                BlockNumberOrTag::Latest,
+                                BlockTransactionsKind::Full,
+                            )
+                            .await
+                        {
+                            Ok(Some(block)) => {
+                                let header = &block.header;
+                                Some(NewBlock {
+                                    hash: header.hash,
+                                    number: header.number,
+                                    timestamp: header.timestamp,
+                                })
                             }
+                            Ok(None) => None,
+                            Err(_) => None,
                         }
-                    })
-                    .filter_map(|x| x);
+                    }
+                })
+                .filter_map(|x| x);
                 Ok(Box::pin(stream))
             }
         }

--- a/src/collectors/uniswapx_order_collector.rs
+++ b/src/collectors/uniswapx_order_collector.rs
@@ -1,3 +1,4 @@
+use crate::shared::RouteInfo;
 use anyhow::Result;
 use artemis_core::types::{Collector, CollectorStream};
 use async_trait::async_trait;
@@ -9,7 +10,6 @@ use std::str::FromStr;
 use std::string::ToString;
 use tokio::time::Duration;
 use tokio_stream::wrappers::IntervalStream;
-use crate::shared::RouteInfo;
 
 static UNISWAPX_API_URL: &str = "https://api.uniswap.org/v2";
 static POLL_INTERVAL_MS: u64 = 250;
@@ -93,11 +93,16 @@ pub struct UniswapXOrderCollector {
 }
 
 impl UniswapXOrderCollector {
-    pub fn new(chain_id: u64, order_type: OrderType, execute_address: String, api_key: Option<String>) -> Self {
+    pub fn new(
+        chain_id: u64,
+        order_type: OrderType,
+        execute_address: String,
+        api_key: Option<String>,
+    ) -> Self {
         Self {
             client: Client::new(),
             base_url: UNISWAPX_API_URL.to_string(),
-            api_key: api_key.unwrap_or_else(|| "".to_string()),
+            api_key: api_key.unwrap_or_default(),
             chain_id,
             order_type,
             execute_address,
@@ -132,30 +137,30 @@ impl Collector<UniswapXOrder> for UniswapXOrderCollector {
             let api_key = self.api_key.clone();
             async move {
                 tracing::debug!("Polling UniswapX API for new orders");
-                
+
                 #[allow(unused_assignments)]
                 let mut last_error = None;
                 loop {
-                    match client.get(url.clone())
+                    match client
+                        .get(url.clone())
                         .header("x-api-key", api_key.clone())
                         .send()
-                        .await {
-                        Ok(resp) => {
-                            match resp.json::<UniswapXOrderResponse>().await {
-                                Ok(data) => {
-                                    tracing::debug!(
-                                        num_orders = data.orders.len(),
-                                        "Successfully fetched orders from UniswapX API"
-                                    );
-                                    return Ok(data.orders);
-                                },
-                                Err(e) => {
-                                    last_error = Some(e.to_string());
-                                    tracing::warn!(
-                                        error = %e,
-                                        "Failed to parse UniswapX API response, retrying..."
-                                    );
-                                }
+                        .await
+                    {
+                        Ok(resp) => match resp.json::<UniswapXOrderResponse>().await {
+                            Ok(data) => {
+                                tracing::debug!(
+                                    num_orders = data.orders.len(),
+                                    "Successfully fetched orders from UniswapX API"
+                                );
+                                return Ok(data.orders);
+                            }
+                            Err(e) => {
+                                last_error = Some(e.to_string());
+                                tracing::warn!(
+                                    error = %e,
+                                    "Failed to parse UniswapX API response, retrying..."
+                                );
                             }
                         },
                         Err(e) => {
@@ -166,7 +171,7 @@ impl Collector<UniswapXOrder> for UniswapXOrderCollector {
                             );
                         }
                     }
-                    
+
                     if let Some(err) = last_error {
                         tracing::warn!(error = %err, "Error in order stream, retrying...");
                         tokio::time::sleep(Duration::from_millis(1000)).await;
@@ -180,7 +185,7 @@ impl Collector<UniswapXOrder> for UniswapXOrderCollector {
                 Err(e) => {
                     tracing::warn!(error = %e, "Error in order stream, skipping batch");
                     stream::once(async { Err(e) }).right_stream()
-                },
+                }
             },
         )
         .filter_map(|result| async {
@@ -204,9 +209,7 @@ mod tests {
     use artemis_core::types::Collector;
     use futures::StreamExt;
     use mockito::{Mock, Server, ServerGuard};
-    use uniswapx_rs::order::{
-        V2DutchOrder, V3DutchOrder,
-    };
+    use uniswapx_rs::order::{V2DutchOrder, V3DutchOrder};
 
     use super::OrderType;
 

--- a/src/collectors/uniswapx_route_collector.rs
+++ b/src/collectors/uniswapx_route_collector.rs
@@ -18,7 +18,7 @@ use reqwest::{Client, StatusCode};
 
 use crate::{
     aws_utils::cloudwatch_utils::{build_metric_future, CwMetrics, DimensionValue},
-    shared::{normalize_erc20eth_to_native, send_metric_with_order_hash, RouteInfo, MethodParameters},
+    shared::{normalize_erc20eth_to_native, send_metric_with_order_hash, MethodParameters, RouteInfo},
 };
 
 const ROUTING_API: &str = "https://api.uniswap.org/v1/quote";
@@ -120,6 +120,7 @@ pub struct OrderRoute {
     pub quote: String,
     pub quote_gas_adjusted: String,
     pub gas_price_wei: String,
+    /// Specifies how much the same gas usage would cost in quote tokens
     pub gas_use_estimate_quote: String,
     pub gas_use_estimate: String,
     pub route: Vec<Vec<Route>>,
@@ -148,8 +149,8 @@ pub struct RouteResponse {
     pub orders: Vec<Route>,
 }
 
-/// A collector that listens for new orders on UniswapX, and generates a stream of
-/// [events](Route) which contain the order.
+/// A collector that obtains possible Uniswap routes using V2-V4 liquidity for
+/// orders produced by the strategy, and generates a stream of [events](Route).
 pub struct UniswapXRouteCollector {
     pub client: Client,
     pub chain_id: u64,

--- a/src/executors/dutch_executor.rs
+++ b/src/executors/dutch_executor.rs
@@ -17,8 +17,13 @@ use aws_sdk_cloudwatch::Client as CloudWatchClient;
 
 use crate::{
     aws_utils::cloudwatch_utils::{
-        build_metric_future, receipt_status_to_metric, revert_code_to_metric, CwMetrics, DimensionValue
-    }, executors::reactor_error_code::{get_revert_reason, ReactorErrorCode}, send_metric, shared::get_nonce_with_retry, strategies::keystore::KeyStore
+        build_metric_future, receipt_status_to_metric, revert_code_to_metric, CwMetrics,
+        DimensionValue,
+    },
+    executors::reactor_error_code::{get_revert_reason, ReactorErrorCode},
+    send_metric,
+    shared::get_nonce_with_retry,
+    strategies::{dutchv3_strategy::DEFAULT_GAS_PRICE, keystore::KeyStore},
 };
 
 const GAS_LIMIT: u64 = 1_000_000;
@@ -110,7 +115,6 @@ impl Executor<SubmitTxToMempool> for DutchExecutor {
         )
         .expect("Failed to parse chain ID");
 
-
         let wallet = EthereumWallet::from(
             private_key
                 .as_str()
@@ -121,75 +125,75 @@ impl Executor<SubmitTxToMempool> for DutchExecutor {
         let address = addr.parse::<Address>().unwrap();
         action.tx.set_from(address);
 
-
         // Retry up to 3 times to get the nonce.
         let nonce = get_nonce_with_retry(&self.client, address, "", 3).await?;
         action.tx.set_nonce(nonce);
         action.tx.set_gas_limit(GAS_LIMIT);
 
-        let gas_usage_result = self.client.estimate_gas(&action.tx).await.or_else(|err| {
-            if let Some(raw) = &err.as_error_resp().unwrap().data {
-                if let Ok(serde_value) = serde_json::from_str::<serde_json::Value>(raw.get()) {
-                    if let serde_json::Value::String(four_byte) = serde_value {
-                        let error_code = ReactorErrorCode::from(four_byte.clone());
-                        match error_code {
-                            ReactorErrorCode::OrderAlreadyFilled => {
-                                info!("Order already filled, skipping execution");
-                                let metric_future = build_metric_future(
-                                    self.cloudwatch_client.clone(),
-                                    DimensionValue::V3Executor,
-                                    CwMetrics::ExecutionSkippedAlreadyFilled(chain_id),
-                                    1.0,
-                                );
-                                if let Some(metric_future) = metric_future {
-                                    send_metric!(metric_future);
+        let bid_gas_price = if let Some(gas_bid_info) = action.gas_bid_info {
+            // Estimate gas, falling back to 1,000,000 wei
+            let gas_usage_result = self.client.estimate_gas(&action.tx).await.or_else(|err| {
+                if let Some(raw) = &err.as_error_resp().unwrap().data {
+                    if let Ok(serde_value) = serde_json::from_str::<serde_json::Value>(raw.get()) {
+                        if let serde_json::Value::String(four_byte) = serde_value {
+                            let error_code = ReactorErrorCode::from(four_byte.clone());
+                            match error_code {
+                                ReactorErrorCode::OrderAlreadyFilled => {
+                                    info!("Order already filled, skipping execution");
+                                    let metric_future = build_metric_future(
+                                        self.cloudwatch_client.clone(),
+                                        DimensionValue::V3Executor,
+                                        CwMetrics::ExecutionSkippedAlreadyFilled(chain_id),
+                                        1.0,
+                                    );
+                                    if let Some(metric_future) = metric_future {
+                                        send_metric!(metric_future);
+                                    }
+                                    Err(anyhow::anyhow!("Order Already Filled"))
                                 }
-                                Err(anyhow::anyhow!("Order Already Filled"))
-                            }
-                            ReactorErrorCode::InvalidDeadline => {
-                                info!("Order past deadline, skipping execution");
-                                let metric_future = build_metric_future(
-                                    self.cloudwatch_client.clone(),
-                                    DimensionValue::V3Executor,
-                                    CwMetrics::ExecutionSkippedPastDeadline(chain_id),
-                                    1.0,
-                                );
-                                if let Some(metric_future) = metric_future {
-                                    send_metric!(metric_future);
+                                ReactorErrorCode::InvalidDeadline => {
+                                    info!("Order past deadline, skipping execution");
+                                    let metric_future = build_metric_future(
+                                        self.cloudwatch_client.clone(),
+                                        DimensionValue::V3Executor,
+                                        CwMetrics::ExecutionSkippedPastDeadline(chain_id),
+                                        1.0,
+                                    );
+                                    if let Some(metric_future) = metric_future {
+                                        send_metric!(metric_future);
+                                    }
+                                    Err(anyhow::anyhow!("Order Past Deadline"))
                                 }
-                                Err(anyhow::anyhow!("Order Past Deadline"))
+                                _ => Ok(DEFAULT_GAS_PRICE),
                             }
-                            _ => Ok(1_000_000),
+                        } else {
+                            warn!("Unexpected error data: {:?}", serde_value);
+                            Ok(DEFAULT_GAS_PRICE)
                         }
                     } else {
-                        warn!("Unexpected error data: {:?}", serde_value);
-                        Ok(1_000_000)
+                        warn!("Error estimating gas: {:?}", err);
+                        Ok(DEFAULT_GAS_PRICE)
                     }
                 } else {
                     warn!("Error estimating gas: {:?}", err);
-                    Ok(1_000_000)
+                    Ok(DEFAULT_GAS_PRICE)
                 }
-            } else {
-                warn!("Error estimating gas: {:?}", err);
-                Ok(1_000_000)
-            }
-        });
-        info!("Gas Usage {:?}", gas_usage_result);
-        let gas_usage = gas_usage_result.unwrap_or(1_000_000);
+            });
 
-        let bid_gas_price;
-        if let Some(gas_bid_info) = action.gas_bid_info {
+            info!("Gas Usage {:?}", gas_usage_result);
+            let gas_usage = gas_usage_result.unwrap_or(DEFAULT_GAS_PRICE);
+
             // gas price at which we'd break even, meaning 100% of profit goes to validator
             let breakeven_gas_price = gas_bid_info.total_profit / U128::from(gas_usage);
+
             // gas price corresponding to bid percentage
-            bid_gas_price = breakeven_gas_price * gas_bid_info.bid_percentage / U128::from(100);
+            breakeven_gas_price * gas_bid_info.bid_percentage / U128::from(100)
         } else {
-            bid_gas_price = self
-                .client
+            self.client
                 .get_gas_price()
                 .await
-                .map_or_else(|_| U128::from(1), |v| U128::from(v));
-        }
+                .map_or_else(|_| U128::from(1), |v| U128::from(v))
+        };
         info!("bid_gas_price: {}", bid_gas_price);
         action.tx.set_gas_price(bid_gas_price.to());
 
@@ -239,7 +243,13 @@ impl Executor<SubmitTxToMempool> for DutchExecutor {
                         if !status && receipt.block_number.is_some() {
                             info!("Attempting to get revert reason");
                             // Parse revert reason
-                            match get_revert_reason(&self.client, tx_request_for_revert, receipt.block_number.unwrap()).await {
+                            match get_revert_reason(
+                                &self.client,
+                                tx_request_for_revert,
+                                receipt.block_number.unwrap(),
+                            )
+                            .await
+                            {
                                 Ok(reason) => {
                                     info!("Revert reason: {}", reason);
                                     let metric_future = build_metric_future(
@@ -257,8 +267,7 @@ impl Executor<SubmitTxToMempool> for DutchExecutor {
                                     info!("Failed to get revert reason - error: {:?}", e);
                                 }
                             }
-                        }
-                        else {
+                        } else {
                             let send_metric_if_some = |metric| {
                                 if let Some(metric_future) = build_metric_future(
                                     self.cloudwatch_client.clone(),
@@ -300,7 +309,7 @@ impl Executor<SubmitTxToMempool> for DutchExecutor {
 
         // post key-release processing
         // TODO: parse revert reason
-        if let Some(_) = &self.cloudwatch_client {
+        if self.cloudwatch_client.is_some() {
             let metric_future = build_metric_future(
                 self.cloudwatch_client.clone(),
                 DimensionValue::V3Executor,

--- a/src/executors/priority_executor.rs
+++ b/src/executors/priority_executor.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
-use tracing::{info, warn, debug};
+use std::{future::Future, pin::Pin};
+use tracing::{debug, info, warn};
 
 use alloy::{
     eips::{BlockId, BlockNumberOrTag},
@@ -18,20 +19,25 @@ use uniswapx_rs::order::BPS;
 
 use crate::{
     aws_utils::cloudwatch_utils::{
-        build_metric_future, receipt_status_to_metric, CwMetrics, DimensionValue
-    }, 
+        build_metric_future, receipt_status_to_metric, CwMetrics, DimensionValue,
+    },
     executors::{
         bundle_client::BundleClient,
-        transaction_utils::{poll_for_receipt, process_receipt, handle_send_error, TransactionOutcome},
+        transaction_utils::{
+            handle_send_error, poll_for_receipt, process_receipt, TransactionOutcome,
+        },
     },
     shared::{get_nonce_with_retry, send_metric_with_order_hash, u256},
-    strategies::{keystore::KeyStore, types::SubmitTxToMempoolWithExecutionMetadata}
+    strategies::{keystore::KeyStore, types::SubmitTxToMempoolWithExecutionMetadata},
 };
 
 const GAS_LIMIT: u64 = 1_000_000;
 const MAX_RETRIES: u32 = 3;
 const TX_BACKOFF_MS: u64 = 0; // retry immediately
+
+/// Factor to multiply the gas use estimate by
 static QUOTE_BASED_PRIORITY_BID_BUFFER: U256 = u256!(2);
+
 static GWEI_PER_ETH: U256 = u256!(1_000_000_000);
 const QUOTE_ETH_LOG10_THRESHOLD: usize = 8;
 // The number of bps to add to the base bid for each fallback bid
@@ -41,7 +47,7 @@ const RECEIPT_POLL_INTERVAL_MS: u64 = 250;
 // The number of blocks past the target block the bundle is valid for
 const TARGET_BLOCK_BUNDLE_WINDOW: u64 = 4;
 
-const UNICHAIN_ID: u64 = 130;
+pub const UNICHAIN_ID: u64 = 130;
 
 /// An executor that sends transactions to the public mempool.
 pub struct PriorityExecutor {
@@ -78,10 +84,12 @@ impl PriorityExecutor {
         if let Some(cloudwatch_client) = &self.cloudwatch_client {
             let metric = match outcome {
                 Ok(TransactionOutcome::Success(_)) => CwMetrics::TxSucceeded(chain_id),
-                Ok(TransactionOutcome::Failure(_)) | Ok(TransactionOutcome::RetryableFailure) => CwMetrics::TxReverted(chain_id),
+                Ok(TransactionOutcome::Failure(_)) | Ok(TransactionOutcome::RetryableFailure) => {
+                    CwMetrics::TxReverted(chain_id)
+                }
                 Err(_) => CwMetrics::TxStatusUnknown(chain_id),
             };
-            
+
             let metric_future = build_metric_future(
                 Some(cloudwatch_client.clone()),
                 DimensionValue::PriorityExecutor,
@@ -105,22 +113,27 @@ impl PriorityExecutor {
         let tx_request_for_revert = tx_request.clone();
         let tx_envelope = tx_request.build(wallet).await?;
         info!("{} - Sending transaction to RPC", order_hash);
-        
-        match self.sender_client.send_tx_envelope(tx_envelope.clone()).await {
+
+        match self
+            .sender_client
+            .send_tx_envelope(tx_envelope.clone())
+            .await
+        {
             Ok(tx) => {
                 info!("{} - Waiting for confirmations", order_hash);
                 let receipt = match tokio::time::timeout(
                     std::time::Duration::from_secs(CONFIRMATION_TIMEOUT_SEC),
-                    tx.with_required_confirmations(0).get_receipt()
-                ).await {
+                    tx.with_required_confirmations(0).get_receipt(),
+                )
+                .await
+                {
                     Ok(receipt_result) => receipt_result.ok(),
                     Err(_) => {
                         warn!("{} - Timed out waiting for transaction receipt", order_hash);
                         return Ok(TransactionOutcome::Failure(None));
                     }
                 };
-                
-                // Process receipt
+
                 process_receipt(
                     receipt,
                     &self.client,
@@ -129,14 +142,22 @@ impl PriorityExecutor {
                     chain_id,
                     target_block,
                     self.cloudwatch_client.clone(),
-                ).await
+                )
+                .await
             }
             Err(e) => {
-                handle_send_error(e.into(), &self.sender_client, wallet, &tx_request_for_revert, order_hash).await
+                handle_send_error(
+                    e.into(),
+                    &self.sender_client,
+                    wallet,
+                    &tx_request_for_revert,
+                    order_hash,
+                )
+                .await
             }
         }
     }
-    
+
     async fn send_bundle(
         &self,
         wallet: &EthereumWallet,
@@ -146,30 +167,54 @@ impl PriorityExecutor {
         target_block: u64,
     ) -> Result<TransactionOutcome> {
         let tx_request_for_revert = tx_request.clone();
-        
+
         // Send bundle using bundle client
-        let (tx_envelope, _bundle_hash) = match self.bundle_client
-            .send_bundle(wallet, tx_request, target_block, TARGET_BLOCK_BUNDLE_WINDOW, order_hash)
-            .await {
-                Ok(result) => result,
-                Err(e) => {
-                    return handle_send_error(e, &self.sender_client, wallet, &tx_request_for_revert, order_hash).await;
-                }
-            };
-        
+        let (tx_envelope, _bundle_hash) = match self
+            .bundle_client
+            .send_bundle(
+                wallet,
+                tx_request,
+                target_block,
+                TARGET_BLOCK_BUNDLE_WINDOW,
+                order_hash,
+            )
+            .await
+        {
+            Ok(result) => result,
+            Err(e) => {
+                return handle_send_error(
+                    e,
+                    &self.sender_client,
+                    wallet,
+                    &tx_request_for_revert,
+                    order_hash,
+                )
+                .await;
+            }
+        };
+
         // Poll for transaction receipt
         let receipt = match tokio::time::timeout(
             std::time::Duration::from_secs(CONFIRMATION_TIMEOUT_SEC),
-            poll_for_receipt(&self.sender_client, &self.client, &tx_envelope, target_block, order_hash, CONFIRMATION_TIMEOUT_SEC, RECEIPT_POLL_INTERVAL_MS)
-        ).await {
+            poll_for_receipt(
+                &self.sender_client,
+                &self.client,
+                &tx_envelope,
+                target_block,
+                order_hash,
+                CONFIRMATION_TIMEOUT_SEC,
+                RECEIPT_POLL_INTERVAL_MS,
+            ),
+        )
+        .await
+        {
             Ok(receipt_result) => receipt_result?,
             Err(_) => {
                 warn!("{} - Timed out waiting for transaction receipt", order_hash);
                 return Ok(TransactionOutcome::Failure(None));
             }
         };
-        
-        // Process receipt
+
         process_receipt(
             receipt,
             &self.client,
@@ -178,9 +223,12 @@ impl PriorityExecutor {
             chain_id,
             Some(target_block),
             self.cloudwatch_client.clone(),
-        ).await
+        )
+        .await
     }
 
+    /// Calculates a primary bid and at least 3 fallback bids. Additional bids
+    /// are added based on the quote's magnitude
     fn get_bids_for_order(
         &self,
         action: &SubmitTxToMempoolWithExecutionMetadata,
@@ -193,21 +241,32 @@ impl PriorityExecutor {
             let quote_based_priority_bid = action
                 .metadata
                 .calculate_priority_fee_from_gas_use_estimate(QUOTE_BASED_PRIORITY_BID_BUFFER);
+
             if let Some(bid) = quote_based_priority_bid {
                 bid_priority_fees.push(Some(bid));
                 debug!("{} - quote_based_priority_bid: {:?}", order_hash, bid);
             }
         }
 
-        // If the quote is large in ETH, add more bids
-        // < 1e5 gwei = 1 fallback bid, 1e6 = 2 fallback bids, 1e7 = 3 fallback bids, etc.
+        // If the quote is large in ETH, add more bids based on the quote's magnitude in gwei
+        //
+        // num_fallback_bids = 3 + max(0, log10(quote_in_gwei) - QUOTE_ETH_LOG10_THRESHOLD)
+        //
+        // For QUOTE_ETH_LOG10_THRESHOLD = 8:
+        //
+        // | Quote (in ETH) | Quote (in Gwei) | log₁₀(Gwei) | Extra bids |
+        // +----------------+-----------------+-------------+------------+
+        // | 0.1 ETH        | 1e8             | 8           | 0          |
+        // | 1 ETH          | 1e9             | 9           | 1          |
+        // | 10 ETH         | 1e10            | 10          | 2          |
+        // | 100 ETH        | 1e11            | 11          | 3          |
         let mut num_fallback_bids = 3;
         if let Some(quote_eth) = action.metadata.quote_eth {
             if quote_eth > U256::from(0) {
                 debug!("{} - Adding fallback bids based on quote size", order_hash);
-                let quote_in_gwei = &quote_eth / GWEI_PER_ETH;
+                let quote_in_gwei = quote_eth / GWEI_PER_ETH;
                 debug!("{} - quote_eth_gwei: {:?}", order_hash, quote_in_gwei);
-                
+
                 if quote_in_gwei > U256::from(0) {
                     let quote_gwei_log10 = quote_in_gwei.log10();
                     debug!("{} - quote_gwei_log10: {:?}", order_hash, quote_gwei_log10);
@@ -223,17 +282,18 @@ impl PriorityExecutor {
         // 9950, 9900, 9800, 9600, 9200, ...
         for i in 0..num_fallback_bids {
             // Check if the shift would cause overflow or if the result would be negative
-            let bid_scale_factor = action.metadata.fallback_bid_scale_factor.unwrap_or(DEFAULT_FALLBACK_BID_SCALE_FACTOR);
+            let bid_scale_factor = action
+                .metadata
+                .fallback_bid_scale_factor
+                .unwrap_or(DEFAULT_FALLBACK_BID_SCALE_FACTOR);
             let bid_reduction = U128::from(bid_scale_factor * (1 << i));
             if bid_reduction >= U128::from(BPS) {
                 // Stop generating more fallback bids
                 break;
             }
-            
+
             let bid_bps = U128::from(BPS) - bid_reduction;
-            let fallback_bid = action
-                .metadata
-                .calculate_priority_fee(bid_bps);
+            let fallback_bid = action.metadata.calculate_priority_fee(bid_bps);
             if let Some(bid) = fallback_bid {
                 bid_priority_fees.push(Some(bid));
                 debug!("{} - fallback_bid_{}: {:?}", order_hash, i, bid);
@@ -250,13 +310,13 @@ impl Executor<SubmitTxToMempoolWithExecutionMetadata> for PriorityExecutor {
     async fn execute(&self, mut action: SubmitTxToMempoolWithExecutionMetadata) -> Result<()> {
         info!("{} - Executing transaction", action.metadata.order_hash);
         let order_hash = Arc::new(action.metadata.order_hash.clone());
-        
+
         // Initialize this variable outside the main logic so we can access it in the cleanup section
         let mut public_address = None;
-        
+
         // Use a closure to handle the main logic with ? operator for early returns
         let result = async {
-            let chain_id_u64 = action
+            let chain_id = action
                 .execution
                 .tx
                 .chain_id()
@@ -265,12 +325,13 @@ impl Executor<SubmitTxToMempoolWithExecutionMetadata> for PriorityExecutor {
             let metric_future = build_metric_future(
                 self.cloudwatch_client.clone(),
                 DimensionValue::PriorityExecutor,
-                CwMetrics::ExecutionAttempted(chain_id_u64),
+                CwMetrics::ExecutionAttempted(chain_id),
                 1.0,
             );
             if let Some(metric_future) = metric_future {
                 send_metric_with_order_hash!(&order_hash, metric_future);
             }
+
             // send keystore metrics
             let keys_in_use = self.key_store.get_keys_in_use();
             let keys_available = self.key_store.get_keys_available();
@@ -278,7 +339,7 @@ impl Executor<SubmitTxToMempoolWithExecutionMetadata> for PriorityExecutor {
             let keys_in_use_future = build_metric_future(
                 self.cloudwatch_client.clone(),
                 DimensionValue::PriorityExecutor,
-                CwMetrics::KeysInUse(chain_id_u64),
+                CwMetrics::KeysInUse(chain_id),
                 keys_in_use as f64,
             );
             if let Some(metric_future) = keys_in_use_future {
@@ -288,26 +349,22 @@ impl Executor<SubmitTxToMempoolWithExecutionMetadata> for PriorityExecutor {
             let keys_available_future = build_metric_future(
                 self.cloudwatch_client.clone(),
                 DimensionValue::PriorityExecutor,
-                CwMetrics::KeysAvailable(chain_id_u64),
+                CwMetrics::KeysAvailable(chain_id),
                 keys_available as f64,
             );
             if let Some(metric_future) = keys_available_future {
                 send_metric_with_order_hash!(&order_hash, metric_future);
             }
 
-            // Acquire a key from the key store
             let (addr, private_key) = self
                 .key_store
                 .acquire_key()
                 .await
                 .context("Failed to acquire key")?;
-            
-            // Store the address for cleanup
-            public_address = Some(addr.clone());
-            
             info!("{} - Acquired key: {}", order_hash, addr);
 
-            let chain_id = chain_id_u64;
+            // Store the address for cleanup
+            public_address = Some(addr.clone());
 
             let wallet = EthereumWallet::from(
                 private_key
@@ -324,7 +381,7 @@ impl Executor<SubmitTxToMempoolWithExecutionMetadata> for PriorityExecutor {
             // always use 1_000_000 gas for now
             let target_block = match action.metadata.target_block {
                 Some(b) => BlockId::Number(b.into()),
-                _ => BlockId::Number(BlockNumberOrTag::Latest),
+                None => BlockId::Number(BlockNumberOrTag::Latest),
             };
 
             info!(
@@ -340,7 +397,7 @@ impl Executor<SubmitTxToMempoolWithExecutionMetadata> for PriorityExecutor {
                 .context("Error getting gas price")?;
             let bid_priority_fees = self.get_bids_for_order(&action, &order_hash);
 
-            if bid_priority_fees.len() == 0 {
+            if bid_priority_fees.is_empty() {
                 info!(
                     "{} - No bid priority fees, indicating quote < amount_out_required; skipping",
                     order_hash
@@ -350,16 +407,15 @@ impl Executor<SubmitTxToMempoolWithExecutionMetadata> for PriorityExecutor {
             }
 
             // Create a tx for each bid
-            let mut tx_requests: Vec<WithOtherFields<TransactionRequest>> = Vec::new();
-            for bid_priority_fee in bid_priority_fees.iter() {
-                if let Some(bid) = bid_priority_fee {
-                    let mut tx_request = action.execution.tx.clone();
-                    let bid_priority_fee_128 = bid.to::<u128>();
-                    tx_request.set_gas_limit(GAS_LIMIT);
-                    tx_request.set_max_fee_per_gas(base_fee + bid_priority_fee_128);
-                    tx_request.set_max_priority_fee_per_gas(bid_priority_fee_128);
-                    tx_requests.push(tx_request);
-                }
+            let mut tx_requests = Vec::<WithOtherFields<TransactionRequest>>::new();
+            for bid in bid_priority_fees.iter().flatten() {
+                let bid = bid.to::<u128>();
+
+                let mut tx_request = action.execution.tx.clone();
+                tx_request.set_gas_limit(GAS_LIMIT);
+                tx_request.set_max_fee_per_gas(base_fee + bid);
+                tx_request.set_max_priority_fee_per_gas(bid);
+                tx_requests.push(tx_request);
             }
 
             // Retry up to 3 times to get the nonce.
@@ -382,28 +438,32 @@ impl Executor<SubmitTxToMempoolWithExecutionMetadata> for PriorityExecutor {
             let metric_future = build_metric_future(
                 self.cloudwatch_client.clone(),
                 DimensionValue::PriorityExecutor,
-                CwMetrics::OrderBid(chain_id_u64),
+                CwMetrics::OrderBid(chain_id),
                 1.0,
             );
             if let Some(metric_future) = metric_future {
                 send_metric_with_order_hash!(&order_hash, metric_future);
             }
-            info!("{} - Executing {} transactions in parallel from {:?} using {} (chain_id: {})", 
-                order_hash, 
-                tx_requests.len(), 
+            info!(
+                "{} - Executing {} transactions in parallel from {:?} using {} (chain_id: {})",
+                order_hash,
+                tx_requests.len(),
                 address,
-                if chain_id_u64 == UNICHAIN_ID { "bundle sending" } else { "direct transaction sending" },
-                chain_id_u64
+                if chain_id == UNICHAIN_ID {
+                    "bundle sending"
+                } else {
+                    "direct transaction sending"
+                },
+                chain_id
             );
 
             let mut attempts = 0;
             let mut success = false;
             let mut block_number = None;
             let mut retryable_failure = true;
-            
+
             // Retry tx submission on retryable failures if none of the transactions succeeded
             while attempts < MAX_RETRIES && !success && retryable_failure {
-
                 let metric_future = build_metric_future(
                     self.cloudwatch_client.clone(),
                     DimensionValue::PriorityExecutor,
@@ -414,20 +474,32 @@ impl Executor<SubmitTxToMempoolWithExecutionMetadata> for PriorityExecutor {
                     send_metric_with_order_hash!(&order_hash, metric_future);
                 }
 
-                // Create futures for all transactions
-                let futures: Vec<_> = tx_requests.iter().map(|tx_request| {
-                    // Use send_bundle for Unichain, send_transaction for Base
-                    if chain_id_u64 == UNICHAIN_ID {
-                        Box::pin(self.send_bundle(&wallet, tx_request.clone(), &order_hash, chain_id_u64, target_block.as_u64().unwrap()))
-                            as std::pin::Pin<Box<dyn std::future::Future<Output = Result<TransactionOutcome>> + Send>>
-                    } else {
-                        Box::pin(self.send_transaction(&wallet, tx_request.clone(), &order_hash, chain_id_u64, target_block.as_u64()))
-                            as std::pin::Pin<Box<dyn std::future::Future<Output = Result<TransactionOutcome>> + Send>>
-                    }
-                }).collect();
+                let tx_futures = tx_requests
+                    .iter()
+                    .map(|tx_request| {
+                        if chain_id == UNICHAIN_ID {
+                            Box::pin(self.send_bundle(
+                                &wallet,
+                                tx_request.clone(),
+                                &order_hash,
+                                chain_id,
+                                target_block.as_u64().unwrap(),
+                            ))
+                                as Pin<Box<dyn Future<Output = Result<TransactionOutcome>> + Send>>
+                        } else {
+                            Box::pin(self.send_transaction(
+                                &wallet,
+                                tx_request.clone(),
+                                &order_hash,
+                                chain_id,
+                                target_block.as_u64(),
+                            ))
+                        }
+                    })
+                    .collect::<Vec<_>>();
 
                 // Wait for all transactions to complete
-                let results = futures::future::join_all(futures).await;
+                let results = futures::future::join_all(tx_futures).await;
 
                 // Check results
                 retryable_failure = false;
@@ -441,13 +513,18 @@ impl Executor<SubmitTxToMempoolWithExecutionMetadata> for PriorityExecutor {
                             let metric_future = build_metric_future(
                                 self.cloudwatch_client.clone(),
                                 DimensionValue::PriorityExecutor,
-                                CwMetrics::OrderFilled(chain_id_u64),
+                                CwMetrics::OrderFilled(chain_id),
                                 1.0,
                             );
                             if let Some(metric_future) = metric_future {
                                 send_metric_with_order_hash!(&order_hash, metric_future);
                             }
-                            info!("{} - Transaction {} succeeded at block {}", order_hash, i, block_number.unwrap());
+                            info!(
+                                "{} - Transaction {} succeeded at block {}",
+                                order_hash,
+                                i,
+                                block_number.unwrap()
+                            );
                             break;
                         }
                         Ok(TransactionOutcome::Failure(result)) => {
@@ -455,7 +532,6 @@ impl Executor<SubmitTxToMempoolWithExecutionMetadata> for PriorityExecutor {
                                 block_number = *result;
                             }
                             // Find the transaction that won the bid and compare the winning bid to our own bid
-                            
                         }
                         Ok(TransactionOutcome::RetryableFailure) => {
                             retryable_failure = true;
@@ -483,11 +559,11 @@ impl Executor<SubmitTxToMempoolWithExecutionMetadata> for PriorityExecutor {
             }
 
             // post key-release processing
-            if let Some(_) = &self.cloudwatch_client {
+            if self.cloudwatch_client.is_some() {
                 let metric_future = build_metric_future(
                     self.cloudwatch_client.clone(),
                     DimensionValue::PriorityExecutor,
-                    receipt_status_to_metric(success, chain_id_u64),
+                    receipt_status_to_metric(success, chain_id),
                     1.0,
                 );
                 if let Some(metric_future) = metric_future {
@@ -525,8 +601,9 @@ impl Executor<SubmitTxToMempoolWithExecutionMetadata> for PriorityExecutor {
             }
 
             Ok(())
-        }.await;
-        
+        }
+        .await;
+
         // Ensure key is released if it was acquired
         if let Some(addr) = public_address {
             match self.key_store.release_key(addr.clone()).await {
@@ -538,7 +615,7 @@ impl Executor<SubmitTxToMempoolWithExecutionMetadata> for PriorityExecutor {
                 }
             }
         }
-        
+
         result
     }
 }
@@ -546,13 +623,13 @@ impl Executor<SubmitTxToMempoolWithExecutionMetadata> for PriorityExecutor {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alloy::primitives::{U256, U128, U64};
+    use crate::strategies::priority_strategy::ExecutionMetadata;
+    use crate::strategies::types::SubmitTxToMempoolWithExecutionMetadata;
     use alloy::network::AnyNetwork;
+    use alloy::primitives::{U128, U256, U64};
     use alloy::providers::{DynProvider, Provider, RootProvider};
     use alloy::rpc::types::TransactionRequest;
-    use crate::strategies::types::SubmitTxToMempoolWithExecutionMetadata;
-    use crate::strategies::priority_strategy::ExecutionMetadata;
-    use artemis_core::executors::mempool_executor::{SubmitTxToMempool, GasBidInfo};
+    use artemis_core::executors::mempool_executor::{GasBidInfo, SubmitTxToMempool};
     use std::sync::Arc;
 
     // Mock provider that implements the Provider trait
@@ -604,8 +681,8 @@ mod tests {
         );
 
         let action = create_test_action(
-            U256::from(9e17), // quote: 0.9 ETH
-            U256::from(8e17), // amount_required: 0.8 ETH
+            U256::from(9e17),   // quote: 0.9 ETH
+            U256::from(8e17),   // amount_required: 0.8 ETH
             U256::from(100000), // gas_estimate: 100k gas
             false,
             None,
@@ -627,8 +704,8 @@ mod tests {
 
         let action = create_test_action(
             U256::from(1000e18), // quote: 1000 ETH
-            U256::from(900e18), // amount_required: 900 ETH
-            U256::from(100000), // gas_estimate: 100k gas
+            U256::from(900e18),  // amount_required: 900 ETH
+            U256::from(100000),  // gas_estimate: 100k gas
             false,
             None,
         );
@@ -671,7 +748,7 @@ mod tests {
         let action = create_test_action(
             U256::from(2e17), // quote: 0.2 ETH
             U256::from(1e17), // amount_required: 0.1 ETH
-            U256::from(0), // gas_estimate: 0 gas
+            U256::from(0),    // gas_estimate: 0 gas
             false,
             None,
         );
@@ -690,8 +767,8 @@ mod tests {
         );
 
         let action = create_test_action(
-            U256::from(2e17), // quote: 0.2 ETH
-            U256::from(3e17), // amount_required: 0.3 ETH
+            U256::from(2e17),  // quote: 0.2 ETH
+            U256::from(3e17),  // amount_required: 0.3 ETH
             U256::from(10000), // gas_estimate: 10000 gas
             false,
             None,
@@ -711,8 +788,8 @@ mod tests {
         );
 
         let action = create_test_action(
-            U256::from(1e30), // quote: 1e12 ETH
-            U256::from(1e29), // amount_required: 1e11 ETH
+            U256::from(1e30),   // quote: 1e30 ETH
+            U256::from(1e29),   // amount_required: 1e29 ETH
             U256::from(100000), // gas_estimate: 100k gas
             false,
             None,

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,13 +3,6 @@ use anyhow::Result;
 use backoff::ExponentialBackoff;
 use clap::{ArgGroup, Parser};
 
-use artemis_core::engine::Engine;
-use artemis_core::types::{CollectorMap, ExecutorMap};
-use collectors::uniswapx_order_collector::OrderType;
-use collectors::{
-    block_collector::BlockCollector, uniswapx_order_collector::UniswapXOrderCollector,
-    uniswapx_route_collector::UniswapXRouteCollector,
-};
 use alloy::{
     hex,
     network::AnyNetwork,
@@ -17,6 +10,13 @@ use alloy::{
     pubsub::{ConnectionHandle, PubSubConnect},
     signers::local::PrivateKeySigner,
     transports::{impl_future, TransportResult},
+};
+use artemis_core::engine::Engine;
+use artemis_core::types::{CollectorMap, ExecutorMap};
+use collectors::uniswapx_order_collector::OrderType;
+use collectors::{
+    block_collector::BlockCollector, uniswapx_order_collector::UniswapXOrderCollector,
+    uniswapx_route_collector::UniswapXRouteCollector,
 };
 use executors::dutch_executor::DutchExecutor;
 use executors::queued_executor::QueuedExecutor;
@@ -39,7 +39,7 @@ pub mod executors;
 pub mod shared;
 pub mod strategies;
 
-/// CLI Options.
+/// CLI options.
 #[derive(Parser, Debug)]
 #[command(group(
     ArgGroup::new("key_source")
@@ -63,7 +63,7 @@ pub struct Args {
     #[arg(long, group = "key_source")]
     pub private_key: Option<String>,
 
-    /// Path to file containing mapping between public address and private key.
+    /// Path to file mapping public addresss to private keys.
     #[arg(long, group = "key_source")]
     pub private_key_file: Option<String>,
 
@@ -72,18 +72,34 @@ pub struct Args {
     #[arg(long, group = "key_source")]
     pub aws_secret_arn: Option<String>,
 
-    /// Percentage of profit to pay in gas.
+    /// Percentage of profit to pay in gas [0, 100]
+    ///
+    /// If set too low, the minimum gas price to execute the fill transaction will not be reached.
+    ///
+    /// Only for Dutch v3 executor.
     #[arg(long, required = false)]
     pub bid_percentage: Option<u128>,
 
-    /// Determines how aggressive to scale the fallback bids
-    /// 100 (default) = 1% of the profit
+    /// In addition to the bid, multiple fallback bids are placed. This
+    /// parameter determines how aggressively to scale these fallback bids.
+    ///
+    /// Only for priority executor.
+    ///
+    /// 100 = 1% of the profit
+    ///
+    /// The default value is 50, see DEFAULT_FALLBACK_BID_SCALE_FACTOR.
     #[arg(long, required = false)]
     pub fallback_bid_scale_factor: Option<u64>,
 
-    /// Minimum block percentage buffer for priority orders.
-    /// This determines how much time to wait before the target block to submit the fill transaction.
+    /// Minimum block percentage buffer.
+    ///
+    /// Only for priority executor.
+    ///
+    /// Determines how much time to wait before the target block to submit the fill transaction.
+    ///
     /// Example: 120 = 120% of the block time which would be 2.4 seconds with a block time of 2 seconds.
+    ///
+    /// Defaults to 100.
     #[arg(long, required = false)]
     pub min_block_percentage_buffer: Option<u64>,
 
@@ -91,17 +107,19 @@ pub struct Args {
     #[arg(long, required = true)]
     pub executor_address: String,
 
-    /// Order type to use.
+    /// Only fetch UniswapX orders with the specified type.
+    ///
+    /// Options: DutchV2, DutchV3, Priority
     #[arg(long, required = true)]
     pub order_type: OrderType,
+
+    /// Fetch UniswapX orders with the specified chain ID.
+    #[arg(long, required = true)]
+    pub chain_id: u64,
 
     /// Enable CloudWatch logging
     #[arg(long, group = "aws_features")]
     pub cloudwatch_metrics: bool,
-
-    /// chain id
-    #[arg(long, required = true)]
-    pub chain_id: u64,
 
     /// Optional UniswapX API Key
     #[arg(long)]
@@ -154,10 +172,9 @@ async fn main() -> Result<()> {
     let args = Args::parse();
 
     // Set up ethers provider.
-    let chain_id = args.chain_id;
     let mut client = None;
     let mut sender_client = None;
-    
+
     if let Some(wss) = args.wss {
         let ws = WsConnect::new(wss.as_str());
         let retry_ws = RetryWsConnect(ws);
@@ -166,7 +183,7 @@ async fn main() -> Result<()> {
         let wss_provider = Arc::new(DynProvider::<AnyNetwork>::new(
             ProviderBuilder::new()
                 .network::<AnyNetwork>()
-                .on_client(wss_client)
+                .on_client(wss_client),
         ));
         client = Some(wss_provider.clone());
         sender_client = Some(wss_provider.clone());
@@ -180,16 +197,16 @@ async fn main() -> Result<()> {
         let http_provider = Arc::new(DynProvider::<AnyNetwork>::new(
             ProviderBuilder::new()
                 .network::<AnyNetwork>()
-                .on_client(http_client)
+                .on_client(http_client),
         ));
         // prefer http provider for sending txs
         sender_client = Some(http_provider.clone());
         // prefer wss provider for fetching blocks
-        if !client.is_some() {
+        if client.is_none() {
             client = Some(http_provider.clone());
         }
     }
-    if !client.is_some() {
+    if client.is_none() {
         panic!("No provider found. Please provide either a WSS endpoint (--wss) or an HTTP endpoint (--http).");
     }
 
@@ -230,10 +247,11 @@ async fn main() -> Result<()> {
     }
     info!("Key store initialized with {} keys", key_store.len());
 
-    // Set up engine.
+    // Set up Artemis engine.
     let mut engine = Engine::default();
 
-    // Set up block collector.
+    // Set up Ethereum block collector to fetch each block's hash, number and timestamp.
+    // Used to identify completed orders.
     let block_collector = Box::new(BlockCollector::new(client.clone().unwrap()));
     let block_collector = CollectorMap::new(block_collector, Event::NewBlock);
     engine.add_collector(Box::new(block_collector));
@@ -241,15 +259,16 @@ async fn main() -> Result<()> {
     let (batch_sender, batch_receiver) = channel(512);
     let (route_sender, route_receiver) = channel(512);
 
+    // Set up UniswapX order collector by polling API, see POLL_INTERVAL_MS.
+    // Only fetches orders for given chain ID and order type.
     let uniswapx_order_collector = Box::new(UniswapXOrderCollector::new(
-        chain_id,
+        args.chain_id,
         args.order_type.clone(),
         args.executor_address.clone(),
         args.uniswapx_api_key,
     ));
-    let uniswapx_order_collector = CollectorMap::new(uniswapx_order_collector, |e| {
-        Event::UniswapXOrder(Box::new(e))
-    });
+    let uniswapx_order_collector =
+        CollectorMap::new(uniswapx_order_collector, |e| Event::Order(Box::new(e)));
     engine.add_collector(Box::new(uniswapx_order_collector));
 
     let cloudwatch_client = if args.cloudwatch_metrics {
@@ -259,15 +278,16 @@ async fn main() -> Result<()> {
         None
     };
 
+    // Determines possible routes for shortlisted orders using Uniswap API
     let uniswapx_route_collector = Box::new(UniswapXRouteCollector::new(
-        chain_id,
+        args.chain_id,
         batch_receiver,
         route_sender,
         args.executor_address.clone(),
         cloudwatch_client.clone(),
     ));
     let uniswapx_route_collector = CollectorMap::new(uniswapx_route_collector, |e| {
-        Event::UniswapXRoute(Box::new(e))
+        Event::RoutedOrder(Box::new(e))
     });
     engine.add_collector(Box::new(uniswapx_route_collector));
 
@@ -280,39 +300,40 @@ async fn main() -> Result<()> {
 
     match &args.order_type {
         OrderType::DutchV2 => {
-            let uniswapx_strategy = UniswapXUniswapFill::new(
+            let strategy = UniswapXUniswapFill::new(
                 client.clone().unwrap(),
                 config.clone(),
                 batch_sender,
                 route_receiver,
                 cloudwatch_client.clone(),
-                chain_id,
+                args.chain_id,
             );
-            engine.add_strategy(Box::new(uniswapx_strategy));
+            engine.add_strategy(Box::new(strategy));
         }
+
         OrderType::DutchV3 => {
-            let uniswapx_strategy = UniswapXDutchV3Fill::new(
+            let strategy = UniswapXDutchV3Fill::new(
                 client.clone().unwrap(),
                 cloudwatch_client.clone(),
                 config.clone(),
                 batch_sender,
                 route_receiver,
                 key_store.get_address().unwrap(),
-                chain_id,
+                args.chain_id,
             );
-            engine.add_strategy(Box::new(uniswapx_strategy));
+            engine.add_strategy(Box::new(strategy));
         }
+
         OrderType::Priority => {
-            let priority_strategy = UniswapXPriorityFill::new(
+            let strategy = UniswapXPriorityFill::new(
                 client.clone().unwrap(),
                 cloudwatch_client.clone(),
                 config.clone(),
                 batch_sender,
                 route_receiver,
-                chain_id,
+                args.chain_id,
             );
-
-            engine.add_strategy(Box::new(priority_strategy));
+            engine.add_strategy(Box::new(strategy));
         }
     }
 
@@ -341,7 +362,6 @@ async fn main() -> Result<()> {
         _ => None,
     });
 
-
     engine.add_executor(Box::new(queued_executor));
     engine.add_executor(Box::new(protect_executor));
 
@@ -351,17 +371,18 @@ async fn main() -> Result<()> {
             while let Some(res) = set.join_next().await {
                 match res {
                     Ok(res) => {
-                        info!("res: {:?}", res);
+                        info!("res: {res:?}");
                     }
                     Err(e) => {
-                        info!("error: {:?}", e);
+                        info!("error: {e:?}");
                     }
                 }
             }
         }
         Err(e) => {
-            error!("Engine run error: {:?}", e);
+            error!("Engine run error: {e:?}");
         }
     }
+
     Ok(())
 }

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -23,13 +23,13 @@ macro_rules! send_metric_with_order_hash {
     };
 }
 
+pub(crate) use send_metric_with_order_hash;
+
 macro_rules! u256 {
     ($($limb:expr),*) => {
         alloy_primitives::Uint::from_limbs([$($limb, 0, 0, 0),*])
     };
 }
-
-pub(crate) use send_metric_with_order_hash;
 pub(crate) use u256;
 
 /// Normalizes ERC20ETH to native ETH (zero address) for internal processing.
@@ -147,7 +147,7 @@ pub async fn burn_nonce(
         }
         Err(e) => {
             tracing::error!("{} - Error sending nonce burn transaction: {}", order_hash, e);
-            return Err(anyhow::anyhow!("{} - Error sending nonce burn transaction: {}", order_hash, e));
+            Err(anyhow::anyhow!("{} - Error sending nonce burn transaction: {}", order_hash, e))
         }
     }
 }

--- a/src/strategies/dutchv3_strategy.rs
+++ b/src/strategies/dutchv3_strategy.rs
@@ -1,14 +1,16 @@
 use super::{
     shared::UniswapXStrategy,
-    types::{Config, OrderStatus, TokenInTokenOut},
+    types::{Config, TokenInTokenOut},
 };
 use crate::{
-    aws_utils::cloudwatch_utils::{CwMetrics, DimensionName, DimensionValue, MetricBuilder, ARTEMIS_NAMESPACE}, collectors::{
+    aws_utils::cloudwatch_utils::{
+        CwMetrics, DimensionName, DimensionValue, MetricBuilder, ARTEMIS_NAMESPACE,
+    },
+    collectors::{
         block_collector::NewBlock,
         uniswapx_order_collector::UniswapXOrder,
         uniswapx_route_collector::{OrderBatchData, OrderData, RoutedOrder},
-    }, shared::{normalize_erc20eth_to_native, RouteInfo}
-};
+    }, shared::{normalize_erc20eth_to_native, RouteInfo}, send_metric, strategies::shared::DONE_EXPIRY, };
 use alloy::{
     hex,
     network::{AnyNetwork, TransactionBuilder},
@@ -39,15 +41,21 @@ use uniswapx_rs::order::{Order, OrderResolution, V3DutchOrder};
 
 use super::types::{Action, Event};
 
-const DONE_EXPIRY: u64 = 300;
-const REACTOR_ADDRESS: &str = "0xB274d5F4b833b61B340b654d600A864fB604a87c";
+/// If the gas price could not be estimated, use this value
+pub const DEFAULT_GAS_PRICE: u64 = 1_000_000;
+
+/// Minimum gas price on Ethereum chain
+const MIN_ETHEREUM_GAS_PRICE: u64 = 10_000_000;
+
+/// DutchV3OrderReactor contract address on Arbitrum
+const DUTCH_V3_ORDER_REACTOR_ADDRESS: &str = "0xB274d5F4b833b61B340b654d600A864fB604a87c";
 
 #[derive(Debug)]
 #[allow(dead_code)]
 pub struct UniswapXDutchV3Fill {
-    /// Ethers client.
+    /// Ethers client
     client: Arc<DynProvider<AnyNetwork>>,
-    // AWS Cloudwatch CLient for metrics propagation
+    /// AWS Cloudwatch client for metrics propagation
     cloudwatch_client: Option<Arc<CloudWatchClient>>,
     /// executor address
     executor_address: String,
@@ -55,11 +63,11 @@ pub struct UniswapXDutchV3Fill {
     bid_percentage: u128,
     last_block_number: u64,
     last_block_timestamp: u64,
-    // map of open order hashes to order data
+    /// map of open order hashes to order data
     open_orders: HashMap<String, OrderData>,
-    // map of order hashes that are currently being processed (routed/executed)
+    /// map of order hashes that are currently being processed (routed/executed)
     processing_orders: HashSet<String>,
-    // map of done order hashes to time at which we can safely prune them
+    /// map of done order hashes to time at which we can safely prune them
     done_orders: HashMap<String, u64>,
     batch_sender: Sender<Vec<OrderBatchData>>,
     route_receiver: Receiver<RoutedOrder>,
@@ -77,8 +85,6 @@ impl UniswapXDutchV3Fill {
         sender_address: String,
         chain_id: u64,
     ) -> Self {
-        info!("syncing state");
-
         Self {
             client,
             cloudwatch_client,
@@ -101,19 +107,16 @@ impl UniswapXDutchV3Fill {
 
 #[async_trait]
 impl Strategy<Event, Action> for UniswapXDutchV3Fill {
-    // In order to sync this strategy, we need to get the current bid for all Sudo pools.
     async fn sync_state(&mut self) -> Result<()> {
-        info!("syncing state");
-
         Ok(())
     }
 
     // Process incoming events, seeing if we can arb new orders, and updating the internal state on new blocks.
     async fn process_event(&mut self, event: Event) -> Vec<Action> {
         match event {
-            Event::UniswapXOrder(order) => self.process_order_event(&order).await,
+            Event::Order(order) => self.process_order_event(&order).await,
             Event::NewBlock(block) => self.process_new_block_event(&block).await,
-            Event::UniswapXRoute(route) => self.process_new_route(&route).await,
+            Event::RoutedOrder(route) => self.process_new_route(&route).await,
         }
     }
 }
@@ -132,12 +135,13 @@ impl UniswapXDutchV3Fill {
         } else {
             encoded_order
         };
+
         let order_hex: Vec<u8> = hex::decode(encoded_order)?;
 
         V3DutchOrder::decode_inner(&order_hex, false)
     }
 
-    // Process new orders as they come in.
+    /// Process new orders as they come in
     async fn process_order_event(&mut self, event: &UniswapXOrder) -> Vec<Action> {
         if self.last_block_timestamp == 0 || self.processing_orders.contains(&event.order_hash) {
             return vec![];
@@ -145,16 +149,22 @@ impl UniswapXDutchV3Fill {
 
         let order = self
             .decode_order(&event.encoded_order)
-            .map_err(|e| error!("failed to decode: {}", e))
-            .ok();
+            .map_err(|e| error!("failed to decode: {}", e));
 
-        if let Some(order) = order {
-            let wrapper = DutchV3OrderWrapper {
-                inner: order,
-                encoded_order: event.encoded_order.clone(),
-            };
-            self.update_order_state(wrapper, &event.signature, &event.order_hash, event.route.as_ref());
-        }
+        let Ok(order) = order else { return vec![] };
+
+        let wrapper = DutchV3OrderWrapper {
+            inner: order,
+            encoded_order: event.encoded_order.clone(),
+        };
+
+        self.update_order_state(
+            wrapper,
+            &event.signature,
+            &event.order_hash,
+            event.route.as_ref(),
+        );
+
         vec![]
     }
 
@@ -185,7 +195,11 @@ impl UniswapXDutchV3Fill {
         }
 
         let amount_required_u256 = U256::from_str_radix(&amount_required.to_string(), 10).ok();
-        info!("Quote: {:?}, Amount required: {:?}", event.route.quote_gas_adjusted, amount_required_u256);
+        info!(
+            "Quote: {:?}, Amount required: {:?}",
+            event.route.quote_gas_adjusted, amount_required_u256
+        );
+
         if let Some(profit) = self.get_profit_eth(event) {
             info!(
                 "Sending trade: num trades: {} routed quote: {}, batch needs: {}, profit: {} wei",
@@ -200,7 +214,7 @@ impl UniswapXDutchV3Fill {
                     error!("Error getting signed orders: {}", e);
                     vec![]
                 });
-            let tx_request = self
+            let fill_request = self
                 .build_fill(
                     self.client.clone(),
                     &self.executor_address,
@@ -209,32 +223,32 @@ impl UniswapXDutchV3Fill {
                 )
                 .await;
 
-            match tx_request {
-                Ok(mut req) => {
+            match fill_request {
+                Ok(mut fill_req) => {
                     // Must be able to cover min gas cost
                     let sender_address = self.sender_address.parse::<Address>().unwrap();
-                    req.set_from(sender_address);
-                    let gas_usage = self.client.estimate_gas(&req).await.map_or_else(
+                    fill_req.set_from(sender_address);
+                    let gas_usage = self.client.estimate_gas(&fill_req).await.map_or_else(
                         |err| {
                             info!("Error estimating gas: {}", err);
                             if err.to_string().contains("execution reverted") {
                                 None
                             } else {
-                                Some(1_000_000)
+                                Some(DEFAULT_GAS_PRICE)
                             }
                         },
                         Some,
                     );
 
-                    if gas_usage.is_none() {
+                    let Some(gas_usage) = gas_usage else {
                         return vec![];
-                    }
-                    let gas_usage = gas_usage.unwrap();
+                    };
+
                     // Get the current min gas price
                     let min_gas_price = self
                         .get_arbitrum_min_gas_price(self.client.clone())
                         .await
-                        .unwrap_or(U256::from(10_000_000));
+                        .unwrap_or(U256::from(MIN_ETHEREUM_GAS_PRICE));
 
                     // gas price at which we'd break even, meaning 100% of profit goes to validator
                     let breakeven_gas_price = profit / U256::from(gas_usage);
@@ -254,7 +268,7 @@ impl UniswapXDutchV3Fill {
                         self.processing_orders.insert(order.hash.clone());
                     }
                     return vec![Action::SubmitTx(SubmitTxToMempool {
-                        tx: req,
+                        tx: fill_req,
                         gas_bid_info: Some(GasBidInfo {
                             bid_percentage: U128::from(self.bid_percentage),
                             total_profit: U128::from(profit),
@@ -302,7 +316,7 @@ impl UniswapXDutchV3Fill {
     /// encode orders into generic signed orders
     fn get_signed_orders(&self, orders: Vec<OrderData>) -> Result<Vec<SignedOrder>> {
         let mut signed_orders: Vec<SignedOrder> = Vec::new();
-        for batch in orders.iter() {
+        for batch in &orders {
             signed_orders.push(SignedOrder {
                 order: Bytes::from_str(batch.encoded_order.as_ref().unwrap())?,
                 sig: Bytes::from_str(&batch.signature)?,
@@ -314,7 +328,7 @@ impl UniswapXDutchV3Fill {
     fn get_order_batches(&self) -> HashMap<TokenInTokenOut, OrderBatchData> {
         let mut order_batches: HashMap<TokenInTokenOut, OrderBatchData> = HashMap::new();
 
-        // group orders by token in, token out, and order type (exact_in or exact_out)
+        // group orders by token in and token out
         self.open_orders
             .iter()
             .filter(|(_, order_data)| !self.processing_orders.contains(&order_data.hash))
@@ -337,11 +351,19 @@ impl UniswapXDutchV3Fill {
                 } else {
                     amount_out
                 };
+
                 // insert new order and update total amount out
-                if let std::collections::hash_map::Entry::Vacant(e) =
-                    order_batches.entry(token_in_token_out.clone())
-                {
-                    e.insert(OrderBatchData {
+                order_batches
+                    .entry(token_in_token_out.clone())
+                    .and_modify(|order_batch_data| {
+                        order_batch_data.orders.push(order_data.clone());
+                        order_batch_data.amount_in =
+                            order_batch_data.amount_in.wrapping_add(amount_in);
+                        order_batch_data.amount_required = order_batch_data
+                            .amount_required
+                            .wrapping_add(amount_required);
+                    })
+                    .or_insert_with(|| OrderBatchData {
                         orders: vec![order_data.clone()],
                         amount_in,
                         amount_out,
@@ -350,21 +372,13 @@ impl UniswapXDutchV3Fill {
                         token_out: order_data.resolved.outputs[0].token.clone(), // No normalization needed (ERC20ETH won't be output)
                         chain_id: self.chain_id,
                     });
-                } else {
-                    let order_batch_data = order_batches.get_mut(&token_in_token_out).unwrap();
-                    order_batch_data.orders.push(order_data.clone());
-                    order_batch_data.amount_in = order_batch_data.amount_in.wrapping_add(amount_in);
-                    order_batch_data.amount_required = order_batch_data
-                        .amount_required
-                        .wrapping_add(amount_required);
-                }
             });
-        
+
         order_batches
     }
 
     async fn handle_fills(&mut self) -> Result<()> {
-        let reactor_address = REACTOR_ADDRESS.parse::<Address>().unwrap();
+        let reactor_address = DUTCH_V3_ORDER_REACTOR_ADDRESS.parse::<Address>().unwrap();
         let filter = Filter::new()
             .select(self.last_block_number)
             .address(reactor_address)
@@ -380,7 +394,7 @@ impl UniswapXDutchV3Fill {
             // add to done
             self.done_orders.insert(
                 order_hash.to_string(),
-                self.current_timestamp()? + DONE_EXPIRY,
+                self.current_timestamp() + DONE_EXPIRY,
             );
         }
 
@@ -444,41 +458,37 @@ impl UniswapXDutchV3Fill {
         let resolved = order
             .inner
             .resolve(self.last_block_number, self.last_block_timestamp);
-        let order_status: OrderStatus = match resolved {
-            OrderResolution::Expired => OrderStatus::Done,
-            OrderResolution::Invalid => OrderStatus::Done,
-            OrderResolution::Resolved(resolved_order) => OrderStatus::Open(resolved_order),
-            _ => OrderStatus::Done,
-        };
 
-        match order_status {
-            OrderStatus::Done => {
+        match resolved {
+            OrderResolution::Expired
+            | OrderResolution::Invalid
+            | OrderResolution::NotFillableYet(_) => {
                 self.mark_as_done(order_hash);
             }
-            OrderStatus::Open(resolved_order) => {
+
+            OrderResolution::Resolved(resolved_order) => {
                 if self.done_orders.contains_key(order_hash) {
                     info!("{} - Order already done, skipping", order_hash);
                     return;
                 }
                 if !self.open_orders.contains_key(order_hash) {
                     info!("{} - Adding new order", order_hash);
-                    
+
                     if let Some(cw) = &self.cloudwatch_client {
                         let metric_future = cw
                             .put_metric_data()
                             .namespace(ARTEMIS_NAMESPACE)
                             .metric_data(
                                 MetricBuilder::new(CwMetrics::OrderReceived(self.chain_id))
-                                    .add_dimension(DimensionName::Service.as_ref(), DimensionValue::V3Executor.as_ref())
+                                    .add_dimension(
+                                        DimensionName::Service.as_ref(),
+                                        DimensionValue::V3Executor.as_ref(),
+                                    )
                                     .with_value(1.0)
                                     .build(),
                             )
                             .send();
-                        tokio::spawn(async move {
-                            if let Err(e) = metric_future.await {
-                                warn!("Error sending order received metric: {:?}", e);
-                            }
-                        });
+                        send_metric!(metric_future);
                     }
 
                     self.open_orders.insert(
@@ -494,8 +504,6 @@ impl UniswapXDutchV3Fill {
                     );
                 }
             }
-            // Noop
-            _ => {}
         }
     }
 }

--- a/src/strategies/keystore.rs
+++ b/src/strategies/keystore.rs
@@ -54,6 +54,12 @@ pub struct KeyStore {
     keys_in_use_count: Arc<AtomicUsize>,  // Track in-use count efficiently
 }
 
+impl Default for KeyStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl KeyStore {
     pub fn new() -> Self {
         KeyStore {
@@ -72,7 +78,7 @@ impl KeyStore {
 
     // Gets the first key address in the store
     pub fn get_address(&self) -> Option<String> {
-        if self.keys.len() == 0 {
+        if self.keys.is_empty() {
             return None;
         }
         let mut rng = rand::thread_rng();

--- a/src/strategies/priority_strategy.rs
+++ b/src/strategies/priority_strategy.rs
@@ -12,7 +12,9 @@ use crate::{
         uniswapx_route_collector::{OrderBatchData, OrderData, OrderRoute, RoutedOrder},
     },
     shared::{normalize_erc20eth_to_native, RouteInfo},
-    strategies::types::SubmitTxToMempoolWithExecutionMetadata,
+    executors::priority_executor::UNICHAIN_ID,
+    send_metric,
+    strategies::{shared::DONE_EXPIRY, types::SubmitTxToMempoolWithExecutionMetadata},
 };
 use alloy::{
     hex,
@@ -40,27 +42,32 @@ use uniswapx_rs::order::{Order, OrderResolution, PriorityOrder, BPS, MPS};
 
 use super::types::{Action, Event};
 
-const DONE_EXPIRY: u64 = 300;
-// Base addresses
-const REACTOR_ADDRESS: &str = "0x000000001Ec5656dcdB24D90DFa42742738De729";
+/// 0 = Do not apply a priority fee
+const PRIORITY_FEE_WEI: u64 = 0;
+
+/// PriorityOrderReactor contract on Base chain
+const PRIORITY_ORDER_REACTOR_ADDRESS: &str = "0x000000001Ec5656dcdB24D90DFa42742738De729";
+
 pub const WETH_ADDRESS: &str = "0x4200000000000000000000000000000000000006";
+
+const MIN_BLOCK_PERCENTAGE_BUFFER_DEFAULT: u64 = 100;
 
 fn get_block_time_ms(chain_id: u64) -> u64 {
     match chain_id {
-        130 => 1000,   // Unichain
-        8453 => 2000,  // Base Mainnet
-        _ => 2000,     // Default to 2 seconds for unknown chains
+        UNICHAIN_ID => 1000, // Unichain
+        8453 => 2000,        // Base Mainnet
+        _ => 2000,           // Default to 2 seconds for unknown chains
     }
 }
 
 #[derive(Debug, Clone)]
 pub struct ExecutionMetadata {
-    // amount of quote token we can get
+    /// amount of quote token we can get
     pub quote: U256,
     pub quote_eth: Option<U256>,
-    // whether the order is an exact output order
+    /// whether the order is an exact output order
     pub exact_output: bool,
-    // amount of quote token needed to fill the order
+    /// amount of quote token needed to fill the order
     pub amount_required: U256,
     pub gas_use_estimate_quote: U256,
     pub order_hash: String,
@@ -94,9 +101,13 @@ impl ExecutionMetadata {
     pub fn calculate_priority_fee(&self, bid_bps: U128) -> Option<U256> {
         // exact_out: quote must be less than amount_in_required
         // exact_in: quote must be greater than amount_out_required
-        if (self.exact_output && self.quote.ge(&self.amount_required)) ||
-           (!self.exact_output && self.quote.le(&self.amount_required)) {
-            info!("{} - quote is not less than amount_required, skipping", self.order_hash);
+        if (self.exact_output && self.quote.ge(&self.amount_required))
+            || (!self.exact_output && self.quote.le(&self.amount_required))
+        {
+            info!(
+                "{} - quote is not less than amount_required, skipping",
+                self.order_hash
+            );
             return None;
         }
 
@@ -111,21 +122,31 @@ impl ExecutionMetadata {
         let mps_of_improvement = profit_quote
             .saturating_mul(U256::from(MPS))
             .checked_div(self.amount_required)?;
+
         let priority_fee = mps_of_improvement
             .checked_mul(U256::from(bid_bps))?
             .checked_div(U256::from(BPS))?;
+
         Some(priority_fee)
     }
 
-    // Uses the gas_use_estimate_quote to calculate the maximum priority fee we can bid
-    // @param gas_buffer: The buffer to multiply the gas use estimate by
+    /// Uses the gas_use_estimate_quote to calculate the maximum priority fee we can bid
+    ///
+    /// - `gas_buffer`: The buffer to multiply the gas use estimate by
     pub fn calculate_priority_fee_from_gas_use_estimate(&self, gas_buffer: U256) -> Option<U256> {
         let gas_with_buffer = U256::from(self.gas_use_estimate_quote).checked_mul(gas_buffer)?;
 
         // exact_out: quote must be less than amount_in_required - gas_with_buffer
         // exact_in: quote must be greater than amount_out_required + gas_with_buffer
-        if (self.exact_output && self.quote.ge(&self.amount_required.checked_sub(gas_with_buffer)?)) ||
-           (!self.exact_output && self.quote.le(&self.amount_required.checked_add(gas_with_buffer)?)) {
+        if (self.exact_output
+            && self
+                .quote
+                .ge(&self.amount_required.checked_sub(gas_with_buffer)?))
+            || (!self.exact_output
+                && self
+                    .quote
+                    .le(&self.amount_required.checked_add(gas_with_buffer)?))
+        {
             return None;
         }
 
@@ -150,7 +171,7 @@ impl ExecutionMetadata {
 }
 
 /// Strategy for filling UniswapX Priority Orders
-/// 
+///
 /// This strategy:
 /// - Tracks new orders from the UniswapX API
 /// - Routes orders through Uniswap's routing API
@@ -170,7 +191,7 @@ pub struct UniswapXPriorityFill {
     fallback_bid_scale_factor: Option<u64>,
     last_block_number: RwLock<u64>,
     last_block_timestamp: RwLock<u64>,
-    // map of new order hashes to order data
+    // map of new order hashes to order data, tracking the route
     new_orders: Arc<DashMap<String, OrderData>>,
     // map of order hashes that are currently being processed (routed/executed)
     processing_orders: Arc<DashMap<String, OrderData>>,
@@ -190,8 +211,6 @@ impl UniswapXPriorityFill {
         receiver: Receiver<RoutedOrder>,
         chain_id: u64,
     ) -> Self {
-        info!("syncing state");
-
         Self {
             client,
             cloudwatch_client,
@@ -213,17 +232,15 @@ impl UniswapXPriorityFill {
 #[async_trait]
 impl Strategy<Event, Action> for UniswapXPriorityFill {
     async fn sync_state(&mut self) -> Result<()> {
-        info!("syncing state");
-
         Ok(())
     }
 
-    // Process incoming events, seeing if we can arb new orders, and updating the internal state on new blocks.
+    /// Process incoming events, seeing if we can arb new orders, and updating the internal state on new blocks
     async fn process_event(&mut self, event: Event) -> Vec<Action> {
         match event {
-            Event::UniswapXOrder(order) => self.process_order_event(&order).await,
+            Event::Order(order) => self.process_order_event(&order).await,
             Event::NewBlock(block) => self.process_new_block_event(&block).await,
-            Event::UniswapXRoute(route) => self.process_new_route(&route).await,
+            Event::RoutedOrder(route) => self.process_new_route(&route).await,
         }
     }
 }
@@ -250,9 +267,9 @@ impl UniswapXPriorityFill {
         } else {
             encoded_order
         };
-        
-        let order_hex = hex::decode(encoded_order)
-            .map_err(|e| format!("Failed to decode hex: {}", e))?;
+
+        let order_hex =
+            hex::decode(encoded_order).map_err(|e| format!("Failed to decode hex: {}", e))?;
 
         PriorityOrder::decode_inner(&order_hex, false)
             .map_err(|e| format!("Failed to decode order: {}", e).into())
@@ -263,19 +280,20 @@ impl UniswapXPriorityFill {
             *self.last_block_number.read().await,
             *self.last_block_timestamp.read().await,
             get_block_time_ms(self.chain_id),
-            Uint::from(0),
-            self.min_block_percentage_buffer.unwrap_or(100)
+            Uint::from(PRIORITY_FEE_WEI),
+            self.min_block_percentage_buffer
+                .unwrap_or(MIN_BLOCK_PERCENTAGE_BUFFER_DEFAULT),
         );
-        let order_status = match resolved_order {
+
+        match resolved_order {
             OrderResolution::Expired | OrderResolution::Invalid => OrderStatus::Done,
             OrderResolution::NotFillableYet(resolved) => OrderStatus::NotFillableYet(resolved),
             OrderResolution::Resolved(resolved) => OrderStatus::Open(resolved),
-        };
-        order_status
+        }
     }
 
     /// Process new order events that we fetch from UniswapX API
-    /// - skip if we are already tracking this order
+    /// - skip if no block has been received yet, or we are already tracking/processing this order
     /// - otherwise decode and process:
     ///     - skip if we have already processed this order
     ///     - immediately send for execution if order is fillable
@@ -288,6 +306,7 @@ impl UniswapXPriorityFill {
             );
             return self.check_orders_for_submission().await;
         }
+
         if self.new_orders.contains_key(&event.order_hash)
             || self.processing_orders.contains_key(&event.order_hash)
         {
@@ -301,7 +320,6 @@ impl UniswapXPriorityFill {
         let order = self
             .decode_order(&event.encoded_order)
             .map_err(|e| error!("failed to decode: {}", e))
-            .ok()
             .unwrap();
 
         let order_hash = event.order_hash.clone();
@@ -318,6 +336,7 @@ impl UniswapXPriorityFill {
                     );
                     return self.check_orders_for_submission().await;
                 }
+
                 let order_data = OrderData {
                     order: Order::PriorityOrder(order.clone()),
                     hash: order_hash.clone(),
@@ -326,30 +345,45 @@ impl UniswapXPriorityFill {
                     encoded_order: None,
                     route: event.route.clone(),
                 };
-                info!("{} - Received {} order", order_hash, if order_data.order.is_exact_output() { "exact_out" } else { "exact_in" });
+
+                info!(
+                    "{} - Received {} order",
+                    order_hash,
+                    if order_data.order.is_exact_output() {
+                        "exact_out"
+                    } else {
+                        "exact_in"
+                    }
+                );
+
                 if let Some(route) = &order_data.route {
                     if !route.method_parameters.calldata.is_empty() {
-                        info!("{} - Received cached route for order with quote: {}", order_hash, route.quote);
+                        info!(
+                            "{} - Received cached route for order with quote: {}",
+                            order_hash, route.quote
+                        );
                     }
                 }
+
                 if let Some(cw) = &self.cloudwatch_client {
                     let metric_future = cw
                         .put_metric_data()
                         .namespace(ARTEMIS_NAMESPACE)
                         .metric_data(
                             MetricBuilder::new(CwMetrics::OrderReceived(self.chain_id))
-                                .add_dimension(DimensionName::Service.as_ref(), DimensionValue::PriorityExecutor.as_ref())
+                                .add_dimension(
+                                    DimensionName::Service.as_ref(),
+                                    DimensionValue::PriorityExecutor.as_ref(),
+                                )
                                 .with_value(1.0)
                                 .build(),
                         )
                         .send();
-                    tokio::spawn(async move {
-                        if let Err(e) = metric_future.await {
-                            warn!("Error sending order received metric: {:?}", e);
-                        }
-                    });
+                    send_metric!(metric_future);
                 }
-                self.new_orders.insert(order_hash.clone(), order_data.clone());
+
+                self.new_orders
+                    .insert(order_hash.clone(), order_data.clone());
 
                 info!(
                     "{} - Route new order at block {}; target: {}",
@@ -358,11 +392,10 @@ impl UniswapXPriorityFill {
                     order.cosignerData.auctionTargetBlock
                 );
                 let order_batch = self.get_order_batch(&order_data);
-                self.try_route_order_batch(order_batch, order_hash)
-                    .await;
+                self.try_route_order_batch(order_batch, order_hash).await;
             }
         }
-        return self.check_orders_for_submission().await
+        return self.check_orders_for_submission().await;
     }
 
     async fn process_new_route(&mut self, event: &RoutedOrder) -> Vec<Action> {
@@ -370,7 +403,7 @@ impl UniswapXPriorityFill {
             .request
             .orders
             .iter()
-            .any(|o: &OrderData| self.done_orders.contains_key(&o.hash))
+            .any(|o| self.done_orders.contains_key(&o.hash))
         {
             info!(
                 "{} - Skipping route with done order",
@@ -399,7 +432,8 @@ impl UniswapXPriorityFill {
                     _ => continue,
                 };
 
-                if let OrderStatus::NotFillableYet(_) = self.get_order_status(resolved_order).await {
+                if let OrderStatus::NotFillableYet(_) = self.get_order_status(resolved_order).await
+                {
                     let order_batch = self.get_order_batch(entry.value());
                     self.try_route_order_batch(order_batch, order.hash.clone())
                         .await;
@@ -413,7 +447,7 @@ impl UniswapXPriorityFill {
         }
 
         // Try to submit the order and return any actions
-        return self.check_orders_for_submission().await
+        return self.check_orders_for_submission().await;
     }
 
     /// Process new block events
@@ -457,11 +491,7 @@ impl UniswapXPriorityFill {
                             .build(),
                     )
                     .send();
-                tokio::spawn(async move {
-                    if let Err(e) = metric_future.await {
-                        warn!("Error sending block metric: {:?}", e);
-                    }
-                });
+                send_metric!(metric_future);
             }
         }
 
@@ -489,18 +519,27 @@ impl UniswapXPriorityFill {
 
     fn get_order_batch(&self, order_data: &OrderData) -> OrderBatchData {
         let amount_in: Uint<256, 4> = order_data.resolved.input.amount;
-        info!("{} - outputs: {:?}", order_data.hash, order_data.resolved.outputs);
+        info!(
+            "{} - outputs: {:?}",
+            order_data.hash, order_data.resolved.outputs
+        );
+
         let amount_out = order_data
             .resolved
             .outputs
             .iter()
             .fold(Uint::from(0), |sum, output| sum.wrapping_add(output.amount));
         info!("{} - amount_out: {:?}", order_data.hash, amount_out);
+
         OrderBatchData {
             orders: vec![order_data.clone()],
             amount_in,
             amount_out,
-            amount_required: if order_data.order.is_exact_output() { amount_in } else { amount_out },
+            amount_required: if order_data.order.is_exact_output() {
+                amount_in
+            } else {
+                amount_out
+            },
             token_in: normalize_erc20eth_to_native(&order_data.resolved.input.token),
             token_out: order_data.resolved.outputs[0].token.clone(), // No normalization needed (ERC20ETH won't be output)
             chain_id: self.chain_id,
@@ -508,7 +547,7 @@ impl UniswapXPriorityFill {
     }
 
     async fn handle_fills(&self) -> Result<()> {
-        let reactor_address = REACTOR_ADDRESS.parse::<Address>().unwrap();
+        let reactor_address = PRIORITY_ORDER_REACTOR_ADDRESS.parse::<Address>().unwrap();
         let filter = Filter::new()
             .select(*self.last_block_number.read().await)
             .address(reactor_address)
@@ -529,36 +568,41 @@ impl UniswapXPriorityFill {
             self.processing_orders.remove(&order_hash);
             self.done_orders.insert(
                 order_hash.to_string(),
-                self.current_timestamp()? + DONE_EXPIRY,
+                self.current_timestamp() + DONE_EXPIRY,
             );
         }
         Ok(())
     }
 
-    /// The profit of a priority order is calculated a bit differently
-    /// Rationale:
-    ///     - we will always bid the base fee
-    ///     - since we have to provide 1 MP (1/1000th of a bp) for every wei of priority fee
-    ///     - we return the data needed to calculate the maximum MPS of improvement we can offer from our quote and the order specs
-    fn get_execution_metadata(
-        &self,
-        routed_order: &RoutedOrder,
-    ) -> Option<ExecutionMetadata> {
+    /// The profit of a priority order is calculated as follows:
+    ///
+    /// - we will always bid the base fee
+    /// - since we have to provide 1 MP, i.e. 1/1000th of a basis point (bp), for every wei of priority fee
+    /// - we return the data needed to calculate the maximum MPS of improvement we can offer from our quote and the order specs
+    fn get_execution_metadata(&self, routed_order: &RoutedOrder) -> Option<ExecutionMetadata> {
         let quote = U256::from_str_radix(&routed_order.route.quote, 10).ok()?;
         let amount_required =
             U256::from_str_radix(&routed_order.request.amount_required.to_string(), 10).ok()?;
-        info!("{} - quote_eth: {:?}", routed_order.request.orders[0].hash, self.get_quote_eth(&routed_order));
-        Some({
-            ExecutionMetadata {
-                quote,
-                quote_eth: self.get_quote_eth(&routed_order),
-                exact_output: routed_order.request.orders[0].order.is_exact_output(),
-                amount_required,
-                gas_use_estimate_quote: U256::from_str_radix(&routed_order.route.gas_use_estimate_quote, 10).ok()?,
-                order_hash: routed_order.request.orders[0].hash.clone(),
-                target_block: routed_order.target_block.map(|b| U64::from(b)),
-                fallback_bid_scale_factor: self.fallback_bid_scale_factor.clone(),
-            }
+        let quote_eth = self.get_quote_eth(routed_order);
+
+        info!(
+            "{} - quote_eth: {:?}",
+            routed_order.request.orders[0].hash, quote_eth
+        );
+
+        Some(ExecutionMetadata {
+            quote,
+            quote_eth,
+            exact_output: routed_order.request.orders[0].order.is_exact_output(),
+            amount_required,
+            gas_use_estimate_quote: U256::from_str_radix(
+                &routed_order.route.gas_use_estimate_quote,
+                10,
+            )
+            .ok()?,
+            order_hash: routed_order.request.orders[0].hash.clone(),
+            target_block: routed_order.target_block.map(U64::from),
+            fallback_bid_scale_factor: self.fallback_bid_scale_factor,
         })
     }
 
@@ -577,11 +621,14 @@ impl UniswapXPriorityFill {
 
         match order_status {
             OrderStatus::Done => {
-                info!("{} - Order is done, removing from new_orders and processing_orders", order_hash);
+                info!(
+                    "{} - Order is done, removing from new_orders and processing_orders",
+                    order_hash
+                );
                 self.new_orders.remove(&order_hash);
                 self.processing_orders.remove(&order_hash);
                 self.done_orders
-                    .insert(order_hash, self.current_timestamp()? + DONE_EXPIRY);
+                    .insert(order_hash, self.current_timestamp() + DONE_EXPIRY);
             }
             OrderStatus::NotFillableYet(resolved_order) | OrderStatus::Open(resolved_order) => {
                 let order_data = OrderData {
@@ -590,15 +637,11 @@ impl UniswapXPriorityFill {
                     signature: signature.to_string(),
                     resolved: resolved_order,
                     encoded_order: None,
-                    route: route,
+                    route,
                 };
-                info!(
-                    "{} - Requesting fresh route for order",
-                    order_hash
-                );
+                info!("{} - Requesting fresh route for order", order_hash);
                 let order_batch = self.get_order_batch(&order_data);
-                self.try_route_order_batch(order_batch, order_hash)
-                    .await;
+                self.try_route_order_batch(order_batch, order_hash).await;
             }
         }
 
@@ -607,15 +650,8 @@ impl UniswapXPriorityFill {
 
     async fn prune_done_orders(&mut self) {
         info!("Pruning done orders");
-        let mut to_remove = Vec::new();
-        for item in self.done_orders.iter() {
-            if *item.value() < *self.last_block_timestamp.read().await {
-                to_remove.push(item.key().clone());
-            }
-        }
-        for order_hash in to_remove {
-            self.done_orders.remove(&order_hash);
-        }
+        let last_ts = *self.last_block_timestamp.read().await;
+        self.done_orders.retain(|_, v| *v >= last_ts);
     }
 
     /// check all new orders we are tracking
@@ -625,7 +661,7 @@ impl UniswapXPriorityFill {
             .new_orders
             .iter()
             .map(|entry| entry.key().clone())
-            .collect::<Vec<String>>();
+            .collect::<Vec<_>>();
 
         for order_hash in order_hashes {
             if let Some(order_data) = self.get_new_order(&order_hash) {
@@ -651,27 +687,26 @@ impl UniswapXPriorityFill {
         }
 
         // After processing orders, check if any can be submitted
-        return self.check_orders_for_submission().await
+        return self.check_orders_for_submission().await;
     }
 
-    async fn try_route_order_batch(
-        &self,
-        order_batch: OrderBatchData,
-        order_hash: String,
-    ) {
-        match self.batch_sender.send(vec![order_batch]).await {
-            Ok(_) => (),
-            Err(e) => {
-                error!(
-                    "{} - Failed to send batch: {}",
-                    order_hash, e
-                );
-            }
+    async fn try_route_order_batch(&self, order_batch: OrderBatchData, order_hash: String) {
+        if let Err(e) = self.batch_sender.send(vec![order_batch]).await {
+            error!("{} - Failed to send batch: {}", order_hash, e);
         }
     }
 
+    /// Iterates over every new priority order that has been routed
+    ///
+    /// - Skip routes that are processing
+    /// - Evaluate order status
+    ///   - Skip if not fillable yet
+    ///   - Remove order if it was completed
+    ///   - If order is ready, place fill transaction
+    ///   - If the metadata cannot be determined, clear the route information and try re-routing
     async fn check_orders_for_submission(&self) -> Vec<Action> {
-        let order_hashes: Vec<String> = self.new_orders
+        let order_hashes: Vec<String> = self
+            .new_orders
             .iter()
             .map(|entry| entry.key().clone())
             .collect();
@@ -681,69 +716,94 @@ impl UniswapXPriorityFill {
         for order_hash in order_hashes {
             if let Some(mut order_data) = self.new_orders.get_mut(&order_hash) {
                 // Skip if no route available
-                if order_data.route.as_ref().map_or(true, |r| r.method_parameters.calldata.is_empty()) {
+                if order_data
+                    .route
+                    .as_ref()
+                    .is_none_or(|r| r.method_parameters.calldata.is_empty())
+                {
                     debug!("{} - No route available, skipping", order_hash);
                     continue;
                 }
+
                 // skip if order is already in processing_orders
                 if self.processing_orders.contains_key(&order_hash) {
-                    debug!("{} - Order is already in processing_orders, skipping", order_hash);
+                    debug!(
+                        "{} - Order is already in processing_orders, skipping",
+                        order_hash
+                    );
                     continue;
                 }
 
-                // Check if order is now fillable
                 let order = match &order_data.order {
                     Order::PriorityOrder(order) => order,
                     _ => continue,
                 };
 
+                // Check if order is now fillable
                 match self.get_order_status(order).await {
                     OrderStatus::Done => {
-                        info!("{} - Order is done, removing from new_orders and processing_orders", order_hash);
+                        info!(
+                            "{} - Order is done, removing from new_orders and processing_orders",
+                            order_hash
+                        );
                         self.new_orders.remove(&order_hash);
                         self.processing_orders.remove(&order_hash);
-                        self.done_orders.insert(
-                            order_hash,
-                            self.current_timestamp().unwrap_or(0) + DONE_EXPIRY,
-                        );
+                        self.done_orders
+                            .insert(order_hash, self.current_timestamp() + DONE_EXPIRY);
                         continue;
                     }
+
                     OrderStatus::NotFillableYet(_) => {
                         debug!("{} - Order is not fillable yet, skipping", order_hash);
                         continue;
                     }
+
                     OrderStatus::Open(_) => {
-                        debug!("{} - Order is open, adding to processing_orders", order_hash);
+                        assert!(order_data.route.is_some());
+
+                        debug!(
+                            "{} - Order is open, adding to processing_orders",
+                            order_hash
+                        );
                         // if already in processing_orders, skip (prevent race condition)
                         if self.processing_orders.contains_key(&order_hash) {
                             continue;
-                        }
-                        else {
-                            self.processing_orders.insert(order_hash.clone(), order_data.value().clone());
+                        } else {
+                            self.processing_orders
+                                .insert(order_hash.clone(), order_data.value().clone());
                         }
 
                         // If EXACT_OUT, quote should be less than amount_required
-                        let quote = U256::from_str_radix(&order_data.route.as_ref().unwrap().quote, 10).unwrap();
-                        if order_data.order.is_exact_output() && quote.ge(&order_data.resolved.input.amount) {
+                        let quote =
+                            U256::from_str_radix(&order_data.route.as_ref().unwrap().quote, 10)
+                                .unwrap();
+                        if order_data.order.is_exact_output()
+                            && quote.ge(&order_data.resolved.input.amount)
+                        {
                             info!("{} - Quote indicates more input than swapper is willing to give, skipping", order_hash);
                             continue;
                         }
                         // If EXACT_IN, quote should be greater than amount_required
-                        else if !order_data.order.is_exact_output() && quote.le(&order_data.resolved.outputs[0].amount) {
+                        else if !order_data.order.is_exact_output()
+                            && quote.le(&order_data.resolved.outputs[0].amount)
+                        {
                             info!("{} - Quote indicates less output than swapper is willing to receive, skipping", order_hash);
                             continue;
                         }
 
                         let routed_order = RoutedOrder {
                             request: self.get_order_batch(order_data.value()),
-                            route: OrderRoute {
-                                quote: order_data.route.as_ref().unwrap().quote.clone(),
-                                quote_gas_adjusted: order_data.route.as_ref().unwrap().quote_gas_adjusted.clone(),
-                                gas_price_wei: order_data.route.as_ref().unwrap().gas_price_wei.clone(),
-                                gas_use_estimate_quote: order_data.route.as_ref().unwrap().gas_use_estimate_quote.clone(),
-                                gas_use_estimate: order_data.route.as_ref().unwrap().gas_use_estimate.clone(),
-                                route: vec![],
-                                method_parameters: order_data.route.as_ref().unwrap().method_parameters.clone(),
+                            route: {
+                                let route = order_data.route.as_ref().unwrap();
+                                OrderRoute {
+                                    quote: route.quote.clone(),
+                                    quote_gas_adjusted: route.quote_gas_adjusted.clone(),
+                                    gas_price_wei: route.gas_price_wei.clone(),
+                                    gas_use_estimate_quote: route.gas_use_estimate_quote.clone(),
+                                    gas_use_estimate: route.gas_use_estimate.clone(),
+                                    route: vec![],
+                                    method_parameters: route.method_parameters.clone(),
+                                }
                             },
                             target_block: Some(order.cosignerData.auctionTargetBlock),
                         };
@@ -753,12 +813,16 @@ impl UniswapXPriorityFill {
                             order_hash
                         );
 
-                        match self.build_fill(
-                            self.client.clone(),
-                            &self.executor_address,
-                            self.get_signed_orders(vec![order_data.value().clone()]).unwrap(),
-                            &routed_order,
-                        ).await {
+                        match self
+                            .build_fill(
+                                self.client.clone(),
+                                &self.executor_address,
+                                self.get_signed_orders(vec![order_data.value().clone()])
+                                    .unwrap(),
+                                &routed_order,
+                            )
+                            .await
+                        {
                             Ok(fill_tx_request) => {
                                 debug!("{} - Successfully built fill transaction", order_hash);
                                 let metadata = self.get_execution_metadata(&routed_order);
@@ -778,13 +842,17 @@ impl UniswapXPriorityFill {
                                             },
                                         );
                                         actions.push(action);
-                                        info!("{} - Successfully queued transaction for submission", order_hash);
+                                        info!(
+                                            "{} - Successfully queued transaction for submission",
+                                            order_hash
+                                        );
                                     }
+
                                     None => {
                                         // Clear the route and refresh
                                         order_data.value_mut().route = None;
                                         // Refresh route and try again
-                                        let order_batch = self.get_order_batch(&order_data.value());
+                                        let order_batch = self.get_order_batch(order_data.value());
                                         self.try_route_order_batch(order_batch, order_hash.clone())
                                             .await;
                                         info!(
@@ -796,6 +864,7 @@ impl UniswapXPriorityFill {
                                     }
                                 }
                             }
+
                             Err(e) => {
                                 error!("{} - Error building fill transaction: {}", order_hash, e);
                                 continue;
@@ -814,21 +883,20 @@ impl UniswapXPriorityFill {
 mod tests {
     use super::*;
 
-
     #[test]
     fn test_calculate_priority_fee_exact_in() {
         // Test case 1: Normal case with profit
         let metadata = ExecutionMetadata::new(
-            U256::from(1000),  // quote
-            Some(U256::from(1000)),  // quote_eth
+            U256::from(1000),       // quote
+            Some(U256::from(1000)), // quote_eth
             false,
-            U256::from(800),   // amount_out_required
-            U256::from(50),    // gas_use_estimate_quote
+            U256::from(800), // amount_out_required
+            U256::from(50),  // gas_use_estimate_quote
             "test_hash",
             None,
             None,
         );
-        
+
         let bid_bps = U128::from(5000); // 50%
         let result = metadata.calculate_priority_fee(bid_bps);
         assert!(result.is_some());
@@ -839,46 +907,46 @@ mod tests {
 
         // Test case 2: Quote equals amount required (no profit)
         let metadata = ExecutionMetadata::new(
-            U256::from(800),   // quote equals amount_out_required
-            Some(U256::from(800)),   // quote_eth
+            U256::from(800),       // quote equals amount_out_required
+            Some(U256::from(800)), // quote_eth
             false,
-            U256::from(800),   // amount_out_required
-            U256::from(50),    // gas_use_estimate_quote
+            U256::from(800), // amount_out_required
+            U256::from(50),  // gas_use_estimate_quote
             "test_hash",
             None,
             None,
         );
-        
+
         let result = metadata.calculate_priority_fee(bid_bps);
         assert!(result.is_none());
 
         // Test case 3: Quote less than amount required
         let metadata = ExecutionMetadata::new(
-            U256::from(700),   // quote less than amount_out_required
-            Some(U256::from(700)),   // quote_eth
+            U256::from(700),       // quote less than amount_out_required
+            Some(U256::from(700)), // quote_eth
             false,
-            U256::from(800),   // amount_out_required
-            U256::from(50),    // gas_use_estimate_quote
+            U256::from(800), // amount_out_required
+            U256::from(50),  // gas_use_estimate_quote
             "test_hash",
             None,
             None,
         );
-        
+
         let result = metadata.calculate_priority_fee(bid_bps);
         assert!(result.is_none());
 
         // Test case 4: Minimal profit case
         let metadata = ExecutionMetadata::new(
-            U256::from(801),   // quote just above amount_out_required
-            Some(U256::from(801)),   // quote_eth
+            U256::from(801),       // quote just above amount_out_required
+            Some(U256::from(801)), // quote_eth
             false,
-            U256::from(800),   // amount_out_required
-            U256::from(50),    // gas_use_estimate_quote
+            U256::from(800), // amount_out_required
+            U256::from(50),  // gas_use_estimate_quote
             "test_hash",
             None,
             None,
         );
-        
+
         let result = metadata.calculate_priority_fee(bid_bps);
         assert!(result.is_some());
         // profit = 1
@@ -888,37 +956,36 @@ mod tests {
 
         // Test case 5: Zero bid_bps
         let metadata = ExecutionMetadata::new(
-            U256::from(1000),  // quote
-            Some(U256::from(1000)),  // quote_eth
+            U256::from(1000),       // quote
+            Some(U256::from(1000)), // quote_eth
             false,
-            U256::from(800),   // amount_out_required
-            U256::from(50),    // gas_use_estimate_quote
+            U256::from(800), // amount_out_required
+            U256::from(50),  // gas_use_estimate_quote
             "test_hash",
             None,
             None,
         );
-        
+
         let zero_bid_bps = U128::from(0);
         let result = metadata.calculate_priority_fee(zero_bid_bps);
         assert!(result.is_some());
         assert_eq!(result.unwrap(), U256::from(0));
     }
 
-
     #[test]
     fn test_calculate_priority_fee_exact_out() {
         // Test case 1: Normal case with profit
         let metadata = ExecutionMetadata::new(
-            U256::from(800),   // quote
-            Some(U256::from(800)),   // quote_eth
-            true,              // exact_output = true
-            U256::from(1000),  // amount_in_required
-            U256::from(50),    // gas_use_estimate_quote
+            U256::from(800),       // quote
+            Some(U256::from(800)), // quote_eth
+            true,                  // exact_output = true
+            U256::from(1000),      // amount_in_required
+            U256::from(50),        // gas_use_estimate_quote
             "test_hash",
             None,
             None,
         );
-        
+
         let bid_bps = U128::from(5000); // 50%
         let result = metadata.calculate_priority_fee(bid_bps);
         assert!(result.is_some());
@@ -929,46 +996,46 @@ mod tests {
 
         // Test case 2: Quote equals amount required (no profit)
         let metadata = ExecutionMetadata::new(
-            U256::from(1000),  // quote equals amount_in_required
-            Some(U256::from(1000)),  // quote_eth
-            true,              // exact_output = true
-            U256::from(1000),  // amount_in_required
-            U256::from(50),    // gas_use_estimate_quote
+            U256::from(1000),       // quote equals amount_in_required
+            Some(U256::from(1000)), // quote_eth
+            true,                   // exact_output = true
+            U256::from(1000),       // amount_in_required
+            U256::from(50),         // gas_use_estimate_quote
             "test_hash",
             None,
-            None
+            None,
         );
-        
+
         let result = metadata.calculate_priority_fee(bid_bps);
         assert!(result.is_none());
 
         // Test case 3: Quote greater than amount required
         let metadata = ExecutionMetadata::new(
-            U256::from(1100),  // quote greater than amount_in_required
-            Some(U256::from(1100)),  // quote_eth
-            true,              // exact_output = true
-            U256::from(1000),  // amount_in_required
-            U256::from(50),    // gas_use_estimate_quote
+            U256::from(1100),       // quote greater than amount_in_required
+            Some(U256::from(1100)), // quote_eth
+            true,                   // exact_output = true
+            U256::from(1000),       // amount_in_required
+            U256::from(50),         // gas_use_estimate_quote
             "test_hash",
             None,
             None,
         );
-        
+
         let result = metadata.calculate_priority_fee(bid_bps);
         assert!(result.is_none());
 
         // Test case 4: Minimal profit case
         let metadata = ExecutionMetadata::new(
-            U256::from(999),   // quote just below amount_in_required
-            Some(U256::from(999)),   // quote_eth
-            true,              // exact_output = true
-            U256::from(1000),  // amount_in_required
-            U256::from(50),    // gas_use_estimate_quote
+            U256::from(999),       // quote just below amount_in_required
+            Some(U256::from(999)), // quote_eth
+            true,                  // exact_output = true
+            U256::from(1000),      // amount_in_required
+            U256::from(50),        // gas_use_estimate_quote
             "test_hash",
             None,
             None,
         );
-        
+
         let result = metadata.calculate_priority_fee(bid_bps);
         assert!(result.is_some());
         // profit = 1
@@ -978,16 +1045,16 @@ mod tests {
 
         // Test case 5: Zero bid_bps
         let metadata = ExecutionMetadata::new(
-            U256::from(800),   // quote
-            Some(U256::from(800)),   // quote_eth
-            true,              // exact_output = true
-            U256::from(1000),  // amount_in_required
-            U256::from(50),    // gas_use_estimate_quote
+            U256::from(800),       // quote
+            Some(U256::from(800)), // quote_eth
+            true,                  // exact_output = true
+            U256::from(1000),      // amount_in_required
+            U256::from(50),        // gas_use_estimate_quote
             "test_hash",
             None,
             None,
         );
-        
+
         let zero_bid_bps = U128::from(0);
         let result = metadata.calculate_priority_fee(zero_bid_bps);
         assert!(result.is_some());
@@ -998,16 +1065,16 @@ mod tests {
     fn test_calculate_priority_fee_from_gas_use_estimate_exact_in() {
         // Test case 1: Normal case with profit
         let metadata = ExecutionMetadata::new(
-            U256::from(1000),  // quote
-            Some(U256::from(1000)),  // quote_eth
+            U256::from(1000),       // quote
+            Some(U256::from(1000)), // quote_eth
             false,
-            U256::from(800),   // amount_out_required
-            U256::from(50),    // gas_use_estimate_quote
+            U256::from(800), // amount_out_required
+            U256::from(50),  // gas_use_estimate_quote
             "test_hash",
             None,
             None,
         );
-        
+
         // With gas buffer of 2x
         let mut gas_buffer = U256::from(2);
         let result = metadata.calculate_priority_fee_from_gas_use_estimate(gas_buffer);
@@ -1018,34 +1085,33 @@ mod tests {
 
         // Test case 2: No profit after gas and required amount
         let metadata = ExecutionMetadata::new(
-            U256::from(1000),  // quote
-            Some(U256::from(1000)),   // quote_eth
+            U256::from(1000),       // quote
+            Some(U256::from(1000)), // quote_eth
             false,
-            U256::from(100),   // amount_out_required
-            U256::from(1000000000),  // gas_use_estimate_quote
+            U256::from(100),        // amount_out_required
+            U256::from(1000000000), // gas_use_estimate_quote
             "test_hash",
             None,
             None,
         );
-        
+
         // With gas buffer of 1x
         gas_buffer = U256::from(1);
         let result = metadata.calculate_priority_fee_from_gas_use_estimate(gas_buffer);
         assert!(result.is_none());
 
-
         // Test case 3: 1 profit after gas and required amount
         let metadata = ExecutionMetadata::new(
-            U256::from(1000),  // quote
-            Some(U256::from(1000)),   // quote_eth
+            U256::from(1000),       // quote
+            Some(U256::from(1000)), // quote_eth
             false,
-            U256::from(900),   // amount_out_required
-            U256::from(99),   // gas_use_estimate_quote
+            U256::from(900), // amount_out_required
+            U256::from(99),  // gas_use_estimate_quote
             "test_hash",
             None,
             None,
         );
-        
+
         // With gas buffer of 1x
         gas_buffer = U256::from(1);
         let result = metadata.calculate_priority_fee_from_gas_use_estimate(gas_buffer);
@@ -1056,16 +1122,16 @@ mod tests {
 
         // Test case 4: Quote less than required amount plus gas
         let metadata = ExecutionMetadata::new(
-            U256::from(1000),  // quote
-            Some(U256::from(1000)),   // quote_eth
+            U256::from(1000),       // quote
+            Some(U256::from(1000)), // quote_eth
             false,
-            U256::from(900),   // amount_out_required
-            U256::from(200),   // gas_use_estimate_quote
+            U256::from(900), // amount_out_required
+            U256::from(200), // gas_use_estimate_quote
             "test_hash",
             None,
             None,
         );
-        
+
         // With gas buffer of 1x (900 + 200 > 1000)
         gas_buffer = U256::from(1);
         let result = metadata.calculate_priority_fee_from_gas_use_estimate(gas_buffer);
@@ -1073,16 +1139,16 @@ mod tests {
 
         // Test case 5: Edge case with zero gas estimate
         let metadata = ExecutionMetadata::new(
-            U256::from(1000),  // quote
-            Some(U256::from(1000)),   // quote_eth
+            U256::from(1000),       // quote
+            Some(U256::from(1000)), // quote_eth
             false,
-            U256::from(800),   // amount_out_required
-            U256::from(0),     // gas_use_estimate_quote
+            U256::from(800), // amount_out_required
+            U256::from(0),   // gas_use_estimate_quote
             "test_hash",
             None,
             None,
         );
-        
+
         // With gas buffer of 2x
         gas_buffer = U256::from(2);
         let result = metadata.calculate_priority_fee_from_gas_use_estimate(gas_buffer);
@@ -1096,16 +1162,16 @@ mod tests {
     fn test_calculate_priority_fee_from_gas_use_estimate_exact_out() {
         // Test case 1: Normal case with profit
         let metadata = ExecutionMetadata::new(
-            U256::from(800),   // quote
-            Some(U256::from(800)),   // quote_eth
-            true,              // exact_output = true
-            U256::from(1000),  // amount_in_required
-            U256::from(50),    // gas_use_estimate_quote
+            U256::from(800),       // quote
+            Some(U256::from(800)), // quote_eth
+            true,                  // exact_output = true
+            U256::from(1000),      // amount_in_required
+            U256::from(50),        // gas_use_estimate_quote
             "test_hash",
             None,
             None,
         );
-        
+
         // With gas buffer of 2x
         let mut gas_buffer = U256::from(2);
         let result = metadata.calculate_priority_fee_from_gas_use_estimate(gas_buffer);
@@ -1116,16 +1182,16 @@ mod tests {
 
         // Test case 2: No profit after gas and required amount
         let metadata = ExecutionMetadata::new(
-            U256::from(999),    // quote just below required
-            Some(U256::from(999)),    // quote_eth
-            true,               // exact_output = true
-            U256::from(1000),   // amount_in_required
-            U256::from(2),      // gas_use_estimate_quote
+            U256::from(999),       // quote just below required
+            Some(U256::from(999)), // quote_eth
+            true,                  // exact_output = true
+            U256::from(1000),      // amount_in_required
+            U256::from(2),         // gas_use_estimate_quote
             "test_hash",
             None,
             None,
         );
-        
+
         // With gas buffer of 1x (999 > 1000 - 2)
         gas_buffer = U256::from(1);
         let result = metadata.calculate_priority_fee_from_gas_use_estimate(gas_buffer);
@@ -1133,16 +1199,16 @@ mod tests {
 
         // Test case 3: 1 wei profit after gas and required amount
         let metadata = ExecutionMetadata::new(
-            U256::from(900),   // quote
-            Some(U256::from(900)),   // quote_eth
-            true,              // exact_output = true
-            U256::from(1000),  // amount_in_required
-            U256::from(99),   // gas_use_estimate_quote
+            U256::from(900),       // quote
+            Some(U256::from(900)), // quote_eth
+            true,                  // exact_output = true
+            U256::from(1000),      // amount_in_required
+            U256::from(99),        // gas_use_estimate_quote
             "test_hash",
             None,
             None,
         );
-        
+
         // With gas buffer of 1x (900 < 1000 - 99)
         gas_buffer = U256::from(1);
         let result = metadata.calculate_priority_fee_from_gas_use_estimate(gas_buffer);
@@ -1153,16 +1219,16 @@ mod tests {
 
         // Test case 4: Quote greater than required amount minus gas
         let metadata = ExecutionMetadata::new(
-            U256::from(900),   // quote
-            Some(U256::from(900)),   // quote_eth
-            true,              // exact_output = true
-            U256::from(1000),  // amount_in_required
-            U256::from(200),   // gas_use_estimate_quote
+            U256::from(900),       // quote
+            Some(U256::from(900)), // quote_eth
+            true,                  // exact_output = true
+            U256::from(1000),      // amount_in_required
+            U256::from(200),       // gas_use_estimate_quote
             "test_hash",
             None,
             None,
         );
-        
+
         // With gas buffer of 1x (900 > 1000 - 200)
         gas_buffer = U256::from(1);
         let result = metadata.calculate_priority_fee_from_gas_use_estimate(gas_buffer);
@@ -1170,16 +1236,16 @@ mod tests {
 
         // Test case 5: Edge case with zero gas estimate
         let metadata = ExecutionMetadata::new(
-            U256::from(800),   // quote
-            Some(U256::from(800)),   // quote_eth
-            true,              // exact_output = true
-            U256::from(1000),  // amount_in_required
-            U256::from(0),     // gas_use_estimate_quote
+            U256::from(800),       // quote
+            Some(U256::from(800)), // quote_eth
+            true,                  // exact_output = true
+            U256::from(1000),      // amount_in_required
+            U256::from(0),         // gas_use_estimate_quote
             "test_hash",
             None,
             None,
         );
-        
+
         // With gas buffer of 2x
         gas_buffer = U256::from(2);
         let result = metadata.calculate_priority_fee_from_gas_use_estimate(gas_buffer);

--- a/src/strategies/shared.rs
+++ b/src/strategies/shared.rs
@@ -24,9 +24,22 @@ use std::{
     time::{SystemTime, UNIX_EPOCH},
 };
 
-const REACTOR_ADDRESS: &str = "0x00000011F84B9aa48e5f8aA8B9897600006289Be";
+/// Seconds after which done orders will be removed
+///
+/// 5 minutes
+pub const DONE_EXPIRY: u64 = 300;
+
+/// If the gas price could not be estimated, this value is used
+pub const DEFAULT_GAS_PRICE: u64 = 1_000_000;
+
+/// V2DutchOrderReactor on Mainnet
+pub const V2_DUTCH_ORDER_REACTOR_ADDRESS: &str = "0x00000011F84B9aa48e5f8aA8B9897600006289Be";
+
+/// Valid on Mainnet, Arbitrum, Unichain, Base
 const PERMIT2_ADDRESS: &str = "0x000000000022D473030F116dDEE9F6B43aC78BA3";
+
 pub const WETH_ADDRESS: &str = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2";
+
 const ARBITRUM_GAS_PRECOMPILE: &str = "0x000000000000000000000000000000000000006C";
 
 sol! {
@@ -39,7 +52,7 @@ sol! {
 
 #[async_trait]
 pub trait UniswapXStrategy {
-    // builds a transaction to fill an order
+    /// Builds transaction to fill given order
     async fn build_fill(
         &self,
         client: Arc<DynProvider<AnyNetwork>>,
@@ -61,19 +74,25 @@ pub trait UniswapXStrategy {
             .await?;
 
         let reactor_approval = self
-            .get_tokens_to_approve(client.clone(), token_out, executor_address, REACTOR_ADDRESS)
+            .get_tokens_to_approve(
+                client.clone(),
+                token_out,
+                executor_address,
+                V2_DUTCH_ORDER_REACTOR_ADDRESS,
+            )
             .await?;
 
         let execute_bytes = &route.method_parameters.calldata;
         let encoded_execute_bytes = hex::decode(&execute_bytes[2..]).expect("Failed to decode hex");
 
-        // abi encode as [tokens to approve to swap router 02, tokens to approve to reactor,  multicall data]
+        // ABI-encode as [tokens to approve to swap router 02, tokens to approve to reactor,  multicall data]
         //               [address[], address[], bytes[]]
         let encoded_calldata = ethabi::encode(&[
             Token::Array(permit2_approval),
             Token::Array(reactor_approval),
             Token::Bytes(encoded_execute_bytes),
         ]);
+
         let orders: Vec<UniversalRouterExecutor::SignedOrder> = signed_orders
             .into_iter()
             .map(|order| UniversalRouterExecutor::SignedOrder {
@@ -81,13 +100,14 @@ pub trait UniswapXStrategy {
                 sig: order.sig,
             })
             .collect();
+
         let call = fill_contract.executeBatch(orders, Bytes::from(encoded_calldata));
         Ok(call.into_transaction_request().with_chain_id(chain_id))
     }
 
-    fn current_timestamp(&self) -> Result<u64> {
-        let start = SystemTime::now();
-        Ok(start.duration_since(UNIX_EPOCH)?.as_secs())
+    fn current_timestamp(&self) -> u64 {
+        let now = SystemTime::now();
+        now.duration_since(UNIX_EPOCH).unwrap().as_secs()
     }
 
     async fn get_tokens_to_approve(
@@ -107,7 +127,9 @@ pub trait UniswapXStrategy {
                 return Ok(vec![]);
             }
         }
+
         let token_contract = ERC20::new(token, client.clone());
+
         let allowance = token_contract
             .allowance(
                 from.parse::<Address>().expect("Error encoding from address"),
@@ -116,6 +138,12 @@ pub trait UniswapXStrategy {
             .call()
             .await
             .expect("Failed to get allowance");
+
+        // Wallets set allowance to U256::MAX to represent "infinite approval".
+        // Comparing the allowance to MAX/2 lets us avoid a strict equality
+        // check.
+        //
+        // If the allowance is below this threshold, the token needs approval.
         if allowance._0 < U256::MAX / U256::from(2) {
             Ok(vec![Token::Address(H160(token.0 .0))])
         } else {
@@ -123,17 +151,21 @@ pub trait UniswapXStrategy {
         }
     }
 
+    /// Returns ETH profit in wei
     fn get_profit_eth(&self, RoutedOrder { request, route, .. }: &RoutedOrder) -> Option<U256> {
         let quote = U256::from_str_radix(&route.quote, 10).ok()?;
         let amount_required =
             U256::from_str_radix(&request.amount_required.to_string(), 10).ok()?;
-        
+
         // exact_out: quote must be less than amount_in_required
         // exact_in: quote must be greater than amount_out_required
-        if (request.orders.first().unwrap().order.is_exact_output() && quote.ge(&amount_required)) ||
-            (!request.orders.first().unwrap().order.is_exact_output() && quote.le(&amount_required)) {
-             return None;
-         }
+        if (request.orders.first().unwrap().order.is_exact_output() && quote.ge(&amount_required))
+            || (!request.orders.first().unwrap().order.is_exact_output()
+                && quote.le(&amount_required))
+        {
+            // No profit
+            return None;
+        }
 
         // exact_out: profit = amount_in_required - quote
         // exact_in: profit = quote - amount_out_required
@@ -147,24 +179,29 @@ pub trait UniswapXStrategy {
             return Some(profit_quote);
         }
 
+        // Convert profit to ETH using the gas estimate:
+        //
+        // gas_use_eth = gas_use_estimate * gas_price_wei
+        // profit_eth = profit_quote * gas_use_eth / gas_use_estimate_quote
         let gas_use_eth = U256::from_str_radix(&route.gas_use_estimate, 10)
             .ok()?
             .saturating_mul(U256::from_str_radix(&route.gas_price_wei, 10).ok()?);
+
         profit_quote
             .saturating_mul(gas_use_eth)
             .checked_div(U256::from_str_radix(&route.gas_use_estimate_quote, 10).ok()?)
     }
 
-    /// Converts the quote amount to ETH equivalent value
-    /// 
+    /// Converts the quote amount to ETH-equivalent value
+    ///
     /// For WETH output tokens, returns the quote directly since it's already in ETH.
     /// For non-WETH output tokens, converts using the following formula:
     /// quote_eth = quote * gas_wei / gas_in_quote
-    /// 
+    ///
     /// # Arguments
     /// * `request` - The order request containing token information
     /// * `route` - The route containing quote and gas estimates
-    /// 
+    ///
     /// # Returns
     /// * `Some(U256)` - The quote value in ETH
     /// * `None` - If any conversion fails or division by zero would occur
@@ -179,6 +216,7 @@ pub trait UniswapXStrategy {
         let gas_use_eth = U256::from_str_radix(&route.gas_use_estimate, 10)
             .ok()?
             .saturating_mul(U256::from_str_radix(&route.gas_price_wei, 10).ok()?);
+
         quote
             .saturating_mul(gas_use_eth)
             .checked_div(U256::from_str_radix(&route.gas_use_estimate_quote, 10).ok()?)

--- a/src/strategies/types.rs
+++ b/src/strategies/types.rs
@@ -11,8 +11,8 @@ use super::priority_strategy::ExecutionMetadata;
 #[derive(Debug, Clone)]
 pub enum Event {
     NewBlock(NewBlock),
-    UniswapXOrder(Box<UniswapXOrder>),
-    UniswapXRoute(Box<RoutedOrder>),
+    Order(Box<UniswapXOrder>),
+    RoutedOrder(Box<RoutedOrder>),
 }
 
 #[derive(Debug, Clone)]

--- a/src/strategies/uniswapx_strategy.rs
+++ b/src/strategies/uniswapx_strategy.rs
@@ -1,6 +1,6 @@
 use super::{
     shared::UniswapXStrategy,
-    types::{Config, OrderStatus, TokenInTokenOut},
+    types::{Config, TokenInTokenOut},
 };
 use crate::{
     aws_utils::cloudwatch_utils::{build_metric_future, CwMetrics, DimensionValue},
@@ -10,6 +10,7 @@ use crate::{
         uniswapx_route_collector::{OrderBatchData, OrderData, RoutedOrder},
     },
     shared::{normalize_erc20eth_to_native, send_metric_with_order_hash, RouteInfo},
+    strategies::shared::{DONE_EXPIRY, V2_DUTCH_ORDER_REACTOR_ADDRESS},
 };
 use alloy::{
     hex,
@@ -35,14 +36,13 @@ use uniswapx_rs::order::{Order, OrderResolution, V2DutchOrder};
 
 use super::types::{Action, Event};
 
+/// Block time in seconds
 const BLOCK_TIME: u64 = 12;
-const DONE_EXPIRY: u64 = 300;
-const REACTOR_ADDRESS: &str = "0x00000011F84B9aa48e5f8aA8B9897600006289Be";
 
 #[derive(Debug)]
 #[allow(dead_code)]
 pub struct UniswapXUniswapFill {
-    /// Ethers client.
+    /// Ethereum client.
     client: Arc<DynProvider<AnyNetwork>>,
     /// executor address
     executor_address: String,
@@ -52,7 +52,9 @@ pub struct UniswapXUniswapFill {
     last_block_timestamp: u64,
     // map of open order hashes to order data
     open_orders: HashMap<String, OrderData>,
-    // map of done order hashes to time at which we can safely prune them
+    // Map of done order hashes to time at which we can safely prune them. The
+    // orders are not removed immediately since we might still receive route
+    // events for them.
     done_orders: HashMap<String, u64>,
     batch_sender: Sender<Vec<OrderBatchData>>,
     route_receiver: Receiver<RoutedOrder>,
@@ -69,8 +71,6 @@ impl UniswapXUniswapFill {
         cloudwatch_client: Option<Arc<CloudWatchClient>>,
         chain_id: u64,
     ) -> Self {
-        info!("syncing state");
-
         Self {
             client,
             executor_address: config.executor_address,
@@ -91,25 +91,23 @@ impl UniswapXUniswapFill {
 
 #[async_trait]
 impl Strategy<Event, Action> for UniswapXUniswapFill {
-    // In order to sync this strategy, we need to get the current bid for all Sudo pools.
     async fn sync_state(&mut self) -> Result<()> {
-        info!("syncing state");
-
         Ok(())
     }
 
     // Process incoming events, seeing if we can arb new orders, and updating the internal state on new blocks.
     async fn process_event(&mut self, event: Event) -> Vec<Action> {
         match event {
-            Event::UniswapXOrder(order) => self.process_order_event(&order).await,
+            Event::Order(order) => self.process_order_event(&order).await,
             Event::NewBlock(block) => self.process_new_block_event(&block).await,
-            Event::UniswapXRoute(route) => self.process_new_route(&route).await,
+            Event::RoutedOrder(route) => self.process_new_route(&route).await,
         }
     }
 }
 
 impl UniswapXStrategy for UniswapXUniswapFill {}
 
+// TODO Rename to UniswapXDutchV2Fill
 impl UniswapXUniswapFill {
     fn decode_order(&self, encoded_order: &str) -> Result<V2DutchOrder, Box<dyn Error>> {
         let encoded_order = if let Some(stripped) = encoded_order.strip_prefix("0x") {
@@ -134,8 +132,14 @@ impl UniswapXUniswapFill {
             .ok();
 
         if let Some(order) = order {
-            self.update_order_state(order, &event.signature, &event.order_hash, event.route.as_ref());
+            self.update_order_state(
+                order,
+                &event.signature,
+                &event.order_hash,
+                event.route.as_ref(),
+            );
         }
+
         vec![]
     }
 
@@ -148,6 +152,7 @@ impl UniswapXUniswapFill {
         {
             return vec![];
         }
+
         let OrderBatchData {
             // orders,
             orders,
@@ -224,12 +229,15 @@ impl UniswapXUniswapFill {
             self.open_orders.len(),
             self.done_orders.len()
         );
+
+        // Remove all pending orders that were filled in the last block
         self.handle_fills().await.unwrap_or_else(|e| {
             error!("{} - Error handling fills: {}", event.number, e);
         });
         self.update_open_orders();
         self.prune_done_orders();
 
+        // Find routes using [UniswapXRouteCollector]
         self.batch_sender
             .send(self.get_order_batches().values().cloned().collect())
             .await
@@ -262,6 +270,7 @@ impl UniswapXUniswapFill {
         Ok(signed_orders)
     }
 
+    /// Derive order batches for all (token in, token out) pairs
     fn get_order_batches(&self) -> HashMap<TokenInTokenOut, OrderBatchData> {
         let mut order_batches: HashMap<TokenInTokenOut, OrderBatchData> = HashMap::new();
 
@@ -273,6 +282,10 @@ impl UniswapXUniswapFill {
                 token_out: order_data.resolved.outputs[0].token.clone(),
             };
 
+            for o in &order_data.resolved.outputs {
+                assert_eq!(o.token, token_in_token_out.token_out);
+            }
+
             let amount_in = order_data.resolved.input.amount;
             let amount_out = order_data
                 .resolved
@@ -281,15 +294,24 @@ impl UniswapXUniswapFill {
                 .fold(Uint::from(0), |sum, output| sum.wrapping_add(output.amount));
 
             let amount_required = if order_data.order.is_exact_output() {
+                // Maximum amount required
                 amount_in
             } else {
+                // Minimum amount required
                 amount_out
             };
+
             // insert new order and update total amount out
-            if let std::collections::hash_map::Entry::Vacant(e) =
-                order_batches.entry(token_in_token_out.clone())
-            {
-                e.insert(OrderBatchData {
+            order_batches
+                .entry(token_in_token_out.clone())
+                .and_modify(|order_batch_data| {
+                    order_batch_data.orders.push(order_data.clone());
+                    order_batch_data.amount_in = order_batch_data.amount_in.wrapping_add(amount_in);
+                    order_batch_data.amount_required = order_batch_data
+                        .amount_required
+                        .wrapping_add(amount_required);
+                })
+                .or_insert_with(|| OrderBatchData {
                     orders: vec![order_data.clone()],
                     amount_in,
                     amount_out,
@@ -298,20 +320,13 @@ impl UniswapXUniswapFill {
                     token_out: order_data.resolved.outputs[0].token.clone(), // No normalization needed (ERC20ETH won't be output)
                     chain_id: self.chain_id,
                 });
-            } else {
-                let order_batch_data = order_batches.get_mut(&token_in_token_out).unwrap();
-                order_batch_data.orders.push(order_data.clone());
-                order_batch_data.amount_in = order_batch_data.amount_in.wrapping_add(amount_in);
-                order_batch_data.amount_required = order_batch_data
-                    .amount_required
-                    .wrapping_add(amount_required);
-            }
         });
+
         order_batches
     }
 
     async fn handle_fills(&mut self) -> Result<()> {
-        let reactor_address = REACTOR_ADDRESS.parse::<Address>().unwrap();
+        let reactor_address = V2_DUTCH_ORDER_REACTOR_ADDRESS.parse::<Address>().unwrap();
         let filter = Filter::new()
             .select(self.last_block_number)
             .address(reactor_address)
@@ -327,7 +342,7 @@ impl UniswapXUniswapFill {
             // add to done
             self.done_orders.insert(
                 order_hash.to_string(),
-                self.current_timestamp()? + DONE_EXPIRY,
+                self.current_timestamp() + DONE_EXPIRY,
             );
         }
 
@@ -341,6 +356,7 @@ impl UniswapXUniswapFill {
                 to_remove.push(order_hash.clone());
             }
         }
+
         for order_hash in to_remove {
             self.done_orders.remove(&order_hash);
         }
@@ -371,33 +387,37 @@ impl UniswapXUniswapFill {
         if self.open_orders.contains_key(order) {
             self.open_orders.remove(order);
         }
+
         if !self.done_orders.contains_key(order) {
             self.done_orders
                 .insert(order.to_string(), self.last_block_timestamp + DONE_EXPIRY);
         }
     }
 
-    fn update_order_state(&mut self, order: V2DutchOrder, signature: &str, order_hash: &String, route: Option<&RouteInfo>) {
-        let resolved = order.resolve(self.last_block_timestamp + BLOCK_TIME);
-        let order_status: OrderStatus = match resolved {
-            OrderResolution::Expired => OrderStatus::Done,
-            OrderResolution::Invalid => OrderStatus::Done,
-            OrderResolution::Resolved(resolved_order) => OrderStatus::Open(resolved_order),
-            _ => OrderStatus::Done,
-        };
-
-        match order_status {
-            OrderStatus::Done => {
+    fn update_order_state(
+        &mut self,
+        order: V2DutchOrder,
+        signature: &str,
+        order_hash: &String,
+        route: Option<&RouteInfo>,
+    ) {
+        match order.resolve(self.last_block_timestamp + BLOCK_TIME) {
+            OrderResolution::Expired
+            | OrderResolution::Invalid
+            | OrderResolution::NotFillableYet(_) => {
                 self.mark_as_done(order_hash);
             }
-            OrderStatus::Open(resolved_order) => {
+
+            OrderResolution::Resolved(resolved_order) => {
                 if self.done_orders.contains_key(order_hash) {
                     info!("{} - Order already done, skipping", order_hash);
                     return;
                 }
+
                 if !self.open_orders.contains_key(order_hash) {
                     info!("{} - Adding new order", order_hash);
                 }
+
                 self.open_orders.insert(
                     order_hash.clone(),
                     OrderData {
@@ -406,12 +426,10 @@ impl UniswapXUniswapFill {
                         signature: signature.to_string(),
                         resolved: resolved_order,
                         encoded_order: None,
-                        route: route.cloned()
+                        route: route.cloned(),
                     },
                 );
             }
-            // Noop
-            _ => {}
         }
     }
 }


### PR DESCRIPTION
Extend the README and add code comments to make the code easier to understand. A few functions were updated to use more idiomatic Rust, but all changes preserve the current behaviour.

Changes:
- Document CLI parameters
- Describe order types, reactors and strategies
- Explain the differences between strategies
- Extract values into constants
- Document and reoganising constants
- Use `send_metric!()` across entire code base
- Address Clippy warnings

Note: Zed applied rustfmt on save, resulting in a slightly larger diff than planned.