### PR TITLE
Account for dutch decay

### DIFF
--- a/src/strategies/dutchv3_strategy.rs
+++ b/src/strategies/dutchv3_strategy.rs
@@ -492,6 +492,11 @@ impl UniswapXDutchV3Fill {
                             route: route.cloned(),
                         },
                     );
+                } else {
+                    // Update the resolved field for existing orders to reflect current auction amounts
+                    if let Some(order_data) = self.open_orders.get_mut(order_hash) {
+                        order_data.resolved = resolved_order;
+                    }
                 }
             }
             // Noop


### PR DESCRIPTION
Currently Artemis doesn't account for dutch decay (only considers the auction start price) so orders go unfilled for pure dutch orders.

Tested E2E with a UniswapX order:
https://arbiscan.io/tx/0xc4af21bd47a3587df5eb617302d9aef4fb0493551acdf77ea60446be85b3d651