### PR TITLE
test: introduce syntax errors in lib.rs for CI testing

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
-pub mod aws_utils;
-pub mod collectors;
-pub mod executors;
-pub mod shared;
+pub mod aws_utils
+pub mod collectos;
+pub mod executor;
+pub mod shared; asdf
 pub mod strategies;


### PR DESCRIPTION
<!-- claude-pr-description-start -->
---
## :sparkles: Claude-Generated Content

## Summary
Test PR that introduces intentional syntax errors and typos in `src/lib.rs` to verify CI/testing behavior.
## Changes
- Remove semicolon from `aws_utils` module declaration (syntax error)
- Rename `collectors` module to `collectos` (typo/breaking change)
- Rename `executors` module to `executor` (typo/breaking change)
- Add trailing junk text `asdf` after `shared` module declaration
## Notes
⚠️ **This PR will break the build** - these changes introduce intentional syntax errors for testing purposes.
<!-- claude-pr-description-end -->