### PR TITLE
docs: add inline comment behavior guidelines for PR reviews

### DIFF
--- a/.claude/prompts/claude-pr-review.md
+++ b/.claude/prompts/claude-pr-review.md
@@ -70,6 +70,39 @@ Before deciding, check existing comments and discussions:
 
 When engineers push back on feedback, assume they have context you're missing. Don't repeat the same point.
 
+## Inline Comment Behavior
+
+You post reviews as `github-actions[bot]`. This identity matters for managing comment threads.
+
+### Comment Resolution
+
+- **Only resolve your own comments** (from `github-actions[bot]`)
+- **Never resolve human comments** - engineers add call-outs, context, and explanations that should remain visible
+- Resolve your comments only when the code addresses the issue
+
+### Self-Replies
+
+**Don't reply to your own comments.** When reviewing code you've previously commented on:
+
+- Issue fixed → resolve the comment silently
+- Issue still present → leave silently, the existing comment speaks for itself
+- Avoid creating reply threads with yourself
+
+### Human Replies
+
+**Carefully consider human replies to your comments.** When someone responds:
+
+- Assume they have context you're missing
+- If they say it's intentional, accept it
+- If they correct you, update your understanding
+- Don't repeat or argue the same point
+
+### Human Comments
+
+- Leave human call-outs alone (context notes, explanations, FYIs)
+- Only respond to direct questions aimed at you
+- Don't resolve conversations between engineers
+
 ## Pattern Examples
 
 **Spot this (mixed concerns):**
@@ -105,8 +138,7 @@ async function chargeCard(amount) {
 async function chargeCard(amount, paymentClient) {
   return paymentClient.charge(amount);
 }
-```
-"
+```"
 
 ## Writing Comments
 


### PR DESCRIPTION
<!-- claude-pr-description-start -->
---
## :sparkles: Claude-Generated Content

## Summary
Adds comprehensive guidelines for inline comment behavior in the Claude PR review prompt, defining how the bot should handle comment resolution, self-replies, and human interactions.
## Changes
- Add "Inline Comment Behavior" section to `.claude/prompts/claude-pr-review.md`
- Define comment resolution rules (only resolve bot's own comments)
- Add self-reply guidelines (avoid replying to own comments)
- Add human reply handling (defer to engineer context)
- Add human comment guidelines (leave call-outs alone)
- Minor formatting fix (remove extra newline)
## Notes
These guidelines help the PR review bot maintain cleaner review threads by avoiding self-replies and respecting human-authored comments and discussions.
<!-- claude-pr-description-end -->