### PR TITLE
chore: docker fix

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,15 @@
+name: docker build
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  docker_build:
+    name: docker build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build Docker image
+        run: docker build --platform=linux/amd64 -t uniswapx-artemis .

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -10,6 +10,10 @@ jobs:
     name: docker build
     runs-on: ubuntu-latest
     steps:
+      - name: Security scanning
+        uses: bullfrogsec/bullfrog@1831f79cce8ad602eef14d2163873f27081ebfb3
+        with:
+          egress-policy: audit
       - uses: actions/checkout@v4
       - name: Build Docker image
         run: docker build --platform=linux/amd64 -t uniswapx-artemis .

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@
 
 # Want to help us make this template better? Share your feedback here: https://forms.gle/ybq9Krt8jtBL3iCk7
 
-ARG RUST_VERSION=1.81
+ARG RUST_VERSION=1.89
 ARG APP_NAME=uniswapx-artemis
 
 ################################################################################


### PR DESCRIPTION
latest version of `alloy` now requires rust edition 2024, which isn't supported in Rust version 1.8.1.

adding a docker-build action to validate docker builds on PRs

<!-- claude-pr-description-start -->
---
## :sparkles: Claude-Generated Content

## Summary
Updates the Docker build configuration to use Rust 1.89 (required by the latest `alloy` version) and adds a CI workflow to validate Docker builds on PRs.
## Changes
- Update Rust version from 1.81 to 1.89 in `Dockerfile`
- Add new GitHub Actions workflow (`.github/workflows/docker-build.yml`) that runs on push to main and on PRs
- Include security scanning with bullfrog in the Docker build workflow
## Notes
The latest version of `alloy` requires Rust edition 2024, which isn't available in Rust 1.81. The CI workflow runs `docker build --platform=linux/amd64` to catch Docker build failures early before merging.
<!-- claude-pr-description-end -->